### PR TITLE
refactor (session): use string IDs in domain and add NoSQL model mapping

### DIFF
--- a/pkg/features/session/domain/domain.go
+++ b/pkg/features/session/domain/domain.go
@@ -9,16 +9,16 @@ import "time"
 // RememberMe: Indicates whether to generate a new token with the same expiration
 // duration as the original one.
 type Session struct {
-	ID                interface{} `bson:"_id"`
-	UserID            interface{} `bson:"user_id" `
-	AccessToken       string      `bson:"-"`
-	AccessTokenExpIn  int64       `bson:"-"`
-	RefreshTokenID    string      `bson:"refresh_token_id"`
-	RefreshToken      string      `bson:"-"`
-	RefreshTokenExpIn int64       `bson:"refresh_token_expires_in"`
-	Revoked           bool        `bson:"revoked"`
-	RememberMe        bool        `bson:"remember_me"`
-	CreatedAt         *time.Time  `bson:"create_at"`
+	ID                string
+	UserID            string
+	AccessToken       string
+	AccessTokenExpIn  int64
+	RefreshTokenID    string
+	RefreshToken      string
+	RefreshTokenExpIn int64
+	Revoked           bool
+	RememberMe        bool
+	CreatedAt         *time.Time
 }
 
 func NewSession(userID string, rememberMe bool) *Session {

--- a/pkg/features/session/model/session_no_sql_model.go
+++ b/pkg/features/session/model/session_no_sql_model.go
@@ -1,0 +1,48 @@
+package model
+
+import (
+	"time"
+
+	"github.com/amorindev/go-cms-tmpl/pkg/features/session/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type SessionNoSqlModel struct {
+	ID                bson.ObjectID `bson:"_id"`
+	UserID            bson.ObjectID `bson:"user_id"`
+	RefreshTokenID    string        `bson:"refresh_token_id"`
+	RefreshTokenExpIn int64         `bson:"refresh_token_expires_in"`
+	Revoked           bool          `bson:"revoked"`
+	RememberMe        bool          `bson:"remember_me"`
+	CreatedAt         *time.Time    `bson:"created_at"`
+}
+
+func (m *SessionNoSqlModel) ToDomain(s *domain.Session) {
+	if m == nil {
+		return
+	}
+
+	s.ID = m.ID.Hex()
+	s.UserID = m.UserID.Hex()
+	s.RefreshTokenID = m.RefreshTokenID
+	s.RefreshTokenExpIn = m.RefreshTokenExpIn
+	s.Revoked = m.Revoked
+	s.RememberMe = m.RememberMe
+	s.CreatedAt = m.CreatedAt
+}
+
+func FromDomain(s *domain.Session, id bson.ObjectID, userID bson.ObjectID) *SessionNoSqlModel {
+	if s == nil {
+		return nil
+	}
+
+	return &SessionNoSqlModel{
+		ID:                id,
+		UserID:            userID,
+		RefreshTokenID:    s.RefreshTokenID,
+		RefreshTokenExpIn: s.RefreshTokenExpIn,
+		Revoked:           s.Revoked,
+		RememberMe:        s.RememberMe,
+		CreatedAt:         s.CreatedAt,
+	}
+}

--- a/pkg/features/session/repository/mongo/find_by_r_token_id.go
+++ b/pkg/features/session/repository/mongo/find_by_r_token_id.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/session/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/session/model"
 	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -22,9 +23,8 @@ func (r *Repository) FindByRTokenID(ctx context.Context, rTokenID, userID string
 		"user_id":          userOID,
 	}
 
-	var session domain.Session
-
-	err = r.Collection.FindOne(ctx, filter).Decode(&session)
+	var sessionModel model.SessionNoSqlModel
+	err = r.Collection.FindOne(ctx, filter).Decode(&sessionModel)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, fmt.Errorf("%w: session not found for user %s and token %s: %w", sharedD.ErrNotFound, userID, rTokenID, err)
@@ -32,13 +32,8 @@ func (r *Repository) FindByRTokenID(ctx context.Context, rTokenID, userID string
 		return nil, fmt.Errorf("error getting session: %w", err)
 	}
 
-	if oid, ok := session.ID.(bson.ObjectID); ok {
-		session.ID = oid.Hex()
-	} else {
-		return nil, fmt.Errorf("invalid session ID type, expected ObjectID got %T", session.ID)
-	}
-
-	session.UserID = userOID.Hex()
+	var session domain.Session
+	sessionModel.ToDomain(&session)
 
 	return &session, nil
 }

--- a/pkg/features/session/repository/mongo/insert.go
+++ b/pkg/features/session/repository/mongo/insert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/session/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/session/model"
 	dShared "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -12,14 +13,13 @@ import (
 
 func (r *Repository) Insert(ctx context.Context, session *domain.Session) error {
 	id := bson.NewObjectID()
-	session.ID = id
 
-	userOID, err := bson.ObjectIDFromHex(session.UserID.(string))
+	userOID, err := bson.ObjectIDFromHex(session.UserID)
 	if err != nil {
 		return dShared.ErrIncorrectID
 	}
 
-	session.UserID = userOID
+	sessionModel := model.FromDomain(session, id, userOID)
 
 	_, err = r.Collection.InsertOne(ctx, session)
 	if err != nil {
@@ -29,8 +29,7 @@ func (r *Repository) Insert(ctx context.Context, session *domain.Session) error 
 		return fmt.Errorf("error inserting session: %w", err)
 	}
 
-	session.ID = id.Hex()
-	session.UserID = userOID.Hex()
+	sessionModel.ToDomain(session)
 
 	return nil
 }

--- a/pkg/features/session/service/create.go
+++ b/pkg/features/session/service/create.go
@@ -9,13 +9,13 @@ import (
 
 func (s *Service) Create(ctx context.Context, session *domain.Session, roles []string, email string) error {
 	// Create access token
-	aToken, aTokenExpIn, err := s.TokenSrv.CreateAccessToken(session.UserID.(string), email, roles)
+	aToken, aTokenExpIn, err := s.TokenSrv.CreateAccessToken(session.UserID, email, roles)
 	if err != nil {
 		return err
 	}
 
 	// Create refresh token
-	rTokenID, rToken, rTokenExpIn, err := s.TokenSrv.CreateRefreshToken(session.UserID.(string), session.RememberMe)
+	rTokenID, rToken, rTokenExpIn, err := s.TokenSrv.CreateRefreshToken(session.UserID, session.RememberMe)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Tasks
- Replace interface{} IDs with string in Session domain
- Remove BSON tags from domain entity
- Introduce SessionNoSqlModel for MongoDB mapping
- Move ObjectID conversion logic to repository layer
- Decouple domain from persistence concerns