### PR TITLE
refactor (roles): use string IDs in domain and add NoSQL model mapping

### DIFF
--- a/pkg/features/admin/service/sign_up.go
+++ b/pkg/features/admin/service/sign_up.go
@@ -43,7 +43,7 @@ func (s *Service) SignUp(ctx context.Context, user *domain.User) error {
 	if err != nil {
 		return sharedD.ManageError(err, "error finding the admin role")
 	}
-	user.RoleIDs = []string{role.ID.(string)}
+	user.RoleIDs = []string{role.ID}
 
 	// save admin
 	err = s.UserRepo.Insert(ctx, user)

--- a/pkg/features/roles/domain/domain.go
+++ b/pkg/features/roles/domain/domain.go
@@ -1,16 +1,16 @@
 package domain
 
 type Role struct {
-	ID            interface{}   `json:"id" bson:"_id"`
+	ID            string   `json:"id" bson:"_id"`
 	Name          string        `json:"name" bson:"name"`
-	PermissionIDs []interface{} `bson:"permission_ids"`
+	PermissionIDs []string `bson:"permission_ids"`
 }
 
 // Initialize PermissionIDs as an empty slice to allow MongoDB $addToSet operations.
 func NewRole(name string) *Role {
 	return &Role{
 		Name:          name,
-		PermissionIDs: []interface{}{},
+		PermissionIDs: []string{},
 	}
 }
 

--- a/pkg/features/roles/model/role_no_sql_model.go
+++ b/pkg/features/roles/model/role_no_sql_model.go
@@ -1,0 +1,49 @@
+package model
+
+import (
+	"github.com/amorindev/go-cms-tmpl/pkg/features/roles/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type RoleNoSqlModel struct {
+	ID            bson.ObjectID   `bson:"_id"`
+	Name          string          `bson:"name"`
+	PermissionIDs []bson.ObjectID `bson:"permission_ids"`
+}
+
+func (m *RoleNoSqlModel) ToDomain(r *domain.Role) {
+	if m == nil {
+		return
+	}
+
+	permissionIDs := make([]string, 0, len(m.PermissionIDs))
+	for _, p := range m.PermissionIDs {
+		permissionIDs = append(permissionIDs, p.Hex())
+	}
+
+	r.ID = m.ID.Hex()
+	r.Name = m.Name
+	r.PermissionIDs = permissionIDs
+}
+
+func FromDomain(r *domain.Role, id bson.ObjectID) (*RoleNoSqlModel, error) {
+	if r == nil {
+		return nil, nil
+	}
+
+	permissionObjectIDs := make([]bson.ObjectID, 0, len(r.PermissionIDs))
+
+	for _, p := range r.PermissionIDs {
+		objID, err := bson.ObjectIDFromHex(p)
+		if err != nil {
+			return nil, err
+		}
+		permissionObjectIDs = append(permissionObjectIDs, objID)
+	}
+
+	return &RoleNoSqlModel{
+		ID:            id,
+		Name:          r.Name,
+		PermissionIDs: permissionObjectIDs,
+	}, nil
+}

--- a/pkg/features/roles/repository/mongo/find_by_name.go
+++ b/pkg/features/roles/repository/mongo/find_by_name.go
@@ -5,17 +5,18 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/roles/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/roles/model"
 	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 )
 
 func (r *Repository) FindByName(ctx context.Context, name string) (*domain.Role, error) {
-	var role domain.Role
+	var userModel model.RoleNoSqlModel
 
 	filter := bson.D{{Key: "name", Value: name}}
 
-	err := r.Collection.FindOne(ctx, filter).Decode(&role)
+	err := r.Collection.FindOne(ctx, filter).Decode(&userModel)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, fmt.Errorf("%w: role with name %s not found: %w", sharedD.ErrNotFound, name, err)
@@ -23,11 +24,9 @@ func (r *Repository) FindByName(ctx context.Context, name string) (*domain.Role,
 		return nil, fmt.Errorf("role with name %s not found: %w", name, err)
 	}
 
-	oID, ok := role.ID.(bson.ObjectID)
-	if !ok {
-		return nil, fmt.Errorf("role ID is not a bson.ObjectID")
-	}
-	role.ID = oID.Hex()
+	
+	var role domain.Role
+	userModel.ToDomain(&role)
 
 	return &role, nil
 }

--- a/pkg/features/roles/repository/mongo/insert.go
+++ b/pkg/features/roles/repository/mongo/insert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/roles/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/roles/model"
 	sharedDomain "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -12,15 +13,21 @@ import (
 
 func (r *Repository) Insert(ctx context.Context, role *domain.Role) error {
 	id := bson.NewObjectID()
-	role.ID = id
+	
+	roleModel, err := model.FromDomain(role, id)
+	if err != nil {
+		return fmt.Errorf("error mapping role to mongo model: %w", err)
+	}
 
-	_, err := r.Collection.InsertOne(ctx, role)
+	_, err = r.Collection.InsertOne(ctx, roleModel)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return fmt.Errorf("%w: error inserting role: %w", sharedDomain.ErrDuplicateKey, err)
 		}
 		return fmt.Errorf("error inserting role: %w", err)
 	}
-	role.ID = id.Hex()
+	
+	roleModel.ToDomain(role)
+	
 	return nil
 }


### PR DESCRIPTION
### Tasks
- Replace interface{} IDs with string in Role domain
- Change PermissionIDs from []interface{} to []string
- Introduce RoleNoSqlModel for MongoDB mapping
- Move ObjectID conversion logic to repository layer
- Decouple domain from MongoDB concerns