### PR TITLE
refactor (permissions): use string IDs in domain and add NoSQL model mapping

### DIFF
--- a/pkg/features/permissions/domain/domain.go
+++ b/pkg/features/permissions/domain/domain.go
@@ -1,8 +1,8 @@
 package domain
 
 type Permission struct {
-	ID   interface{} `json:"id" bson:"_id"`
-	Name string      `json:"name" bson:"name"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
 }
 
 func NewPermission(name PermissionName) *Permission {

--- a/pkg/features/permissions/model/permission_no_sql_model.go
+++ b/pkg/features/permissions/model/permission_no_sql_model.go
@@ -1,0 +1,50 @@
+package model
+
+import (
+	"github.com/amorindev/go-cms-tmpl/pkg/features/permissions/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type PermissionNoSqlModel struct {
+	ID   bson.ObjectID `bson:"_id"`
+	Name string        `bson:"name"`
+}
+
+func (m *PermissionNoSqlModel) ToDomain(p *domain.Permission) {
+	if m == nil {
+		return
+	}
+
+	p.ID = m.ID.Hex()
+	p.Name = m.Name
+}
+
+func FromDomain(p *domain.Permission, id bson.ObjectID) *PermissionNoSqlModel {
+	if p == nil {
+		return nil
+	}
+
+	return &PermissionNoSqlModel{
+		ID:   id,
+		Name: p.Name,
+	}
+}
+
+func ToDomainList(models []*PermissionNoSqlModel) []*domain.Permission {
+	if len(models) == 0 {
+		return []*domain.Permission{}
+	}
+
+	permissions := make([]*domain.Permission, 0, len(models))
+
+	for _, m := range models {
+		if m == nil {
+			continue
+		}
+		var permission domain.Permission
+		m.ToDomain(&permission)
+		permissions = append(permissions, &permission)
+	}
+
+	return permissions
+}

--- a/pkg/features/permissions/repository/mongo/find_by_names.go
+++ b/pkg/features/permissions/repository/mongo/find_by_names.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/permissions/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/permissions/model"
 	"go.mongodb.org/mongo-driver/v2/bson"
 )
 
@@ -25,29 +26,21 @@ func (r *Repository) FindByNames(ctx context.Context, names []domain.PermissionN
 	}
 	defer cursor.Close(ctx)
 
-	var permissions []*domain.Permission
+	var permissionsModel []*model.PermissionNoSqlModel
 
 	for cursor.Next(ctx) {
-		var raw struct {
-			ID   bson.ObjectID `bson:"_id"`
-			Name string        `bson:"name"`
-		}
+		var permssionModel model.PermissionNoSqlModel
 
-		if err := cursor.Decode(&raw); err != nil {
+		if err := cursor.Decode(&permssionModel); err != nil {
 			return nil, fmt.Errorf("error decoding permission document: %w", err)
 		}
 
-		p := &domain.Permission{
-			ID:   raw.ID.Hex(),
-			Name: raw.Name,
-		}
-
-		permissions = append(permissions, p)
+		permissionsModel = append(permissionsModel, &permssionModel)
 	}
 
 	if err := cursor.Err(); err != nil {
 		return nil, fmt.Errorf("cursor error while iterating permissions: %w", err)
 	}
 
-	return permissions, nil
+	return model.ToDomainList(permissionsModel), nil
 }

--- a/pkg/features/permissions/repository/mongo/insert.go
+++ b/pkg/features/permissions/repository/mongo/insert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/permissions/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/permissions/model"
 	sharedDomain "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -12,15 +13,18 @@ import (
 
 func (r *Repository) Insert(ctx context.Context, permission *domain.Permission) error {
 	id := bson.NewObjectID()
-	permission.ID = id
 
-	_, err := r.Collection.InsertOne(ctx, permission)
+	permissionModel := model.FromDomain(permission, id)
+
+	_, err := r.Collection.InsertOne(ctx, permissionModel)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return fmt.Errorf("%w: error inserting permission: %w", sharedDomain.ErrDuplicateKey, err)
 		}
 		return fmt.Errorf("error inserting permission: %w", err)
 	}
-	permission.ID = id.Hex()
+	
+	permissionModel.ToDomain(permission)
+
 	return nil
 }

--- a/pkg/features/roles/initializer/initializer.go
+++ b/pkg/features/roles/initializer/initializer.go
@@ -41,7 +41,7 @@ func (i *Initializer) SeedEssentialRoles(ctx context.Context) error {
 func (i *Initializer) AddPermissionsToRole(ctx context.Context, roleName string, permissions []*permissionD.Permission) error {
 	permissionsIDs := make([]string, 0, len(permissions))
 	for _, permission := range permissions {
-		permissionsIDs = append(permissionsIDs, permission.ID.(string))
+		permissionsIDs = append(permissionsIDs, permission.ID)
 	}
 	err := i.RoleRepo.AssignPermissions(ctx, string(domain.RoleSystemAdmin), permissionsIDs)
 	if err != nil {


### PR DESCRIPTION
### Tasks
- Replace interface{} ID with string in Permission domain
- Remove BSON tags from domain entity
- Introduce PermissionNoSqlModel for MongoDB mapping
- Move ObjectID conversion logic to repository layer
- Add ToDomainList helper for model-to-domain conversion
- Remove type assertions from role initializer
- Fully decouple domain from MongoDB concerns