### PR TITLE
refactor (otp): use string IDs in domain and add NoSQL model mapping

### DIFF
--- a/pkg/features/auth/service/resend_verify_email.go
+++ b/pkg/features/auth/service/resend_verify_email.go
@@ -39,5 +39,5 @@ func (s *Service) ResendVerifyEmail(ctx context.Context, email string) (string, 
 		return "", sharedD.ManageError(err, "error sending email")
 	}
 
-	return otp.ID.(string), nil
+	return otp.ID, nil
 }

--- a/pkg/features/auth/service/sign_in.go
+++ b/pkg/features/auth/service/sign_in.go
@@ -62,7 +62,7 @@ func (s *Service) SignIn(ctx context.Context, email string, password string, rem
 		if err != nil {
 			return nil, nil, "", dShared.ManageError(err, "")
 		}
-		return user, nil, otp.ID.(string), nil
+		return user, nil, otp.ID, nil
 	}
 
 	// Create session

--- a/pkg/features/auth/service/sign_up.go
+++ b/pkg/features/auth/service/sign_up.go
@@ -70,5 +70,5 @@ func (s *Service) SignUp(ctx context.Context, user *domain.User) (string, error)
 	// Clear password hash from memory for security
 	user.UserPassAuth = nil
 
-	return otp.ID.(string), nil
+	return otp.ID, nil
 }

--- a/pkg/features/auth/service/verify_email.go
+++ b/pkg/features/auth/service/verify_email.go
@@ -57,7 +57,7 @@ func (s *Service) VerifyEmail(ctx context.Context, otpID string, otpCode string,
 		return nil, nil, sharedD.ManageError(err, "failed to create user session")
 	}
 
-	err = s.OtpCodeSrv.Delete(ctx, otp.ID.(string))
+	err = s.OtpCodeSrv.Delete(ctx, otp.ID)
 	if err != nil {
 		return nil, nil, sharedD.ManageError(err, "failed to delete OTP code")
 	}

--- a/pkg/features/opt-codes/domain/domain.go
+++ b/pkg/features/opt-codes/domain/domain.go
@@ -7,13 +7,13 @@ import "time"
 // Each code has a specific purpose, an expiration date,
 // and a flag indicating whether it has been used.
 type OtpCode struct {
-	ID        interface{}    `bson:"_id"`
-	UserID    interface{}    `bson:"user_id"`
-	OptCode   string         `bson:"otp_code"`
-	Purpose   OtpCodePurpose `bson:"purpose"`
-	Used      bool           `bson:"used"`
-	ExpiresAt *time.Time     `bson:"expires_at"`
-	CreatedAt *time.Time     `bson:"created_at"`
+	ID        string
+	UserID    string
+	OptCode   string
+	Purpose   OtpCodePurpose
+	Used      bool
+	ExpiresAt *time.Time
+	CreatedAt *time.Time
 }
 
 type OtpCodePurpose string

--- a/pkg/features/opt-codes/model/otp_code_no_sql_model.go
+++ b/pkg/features/opt-codes/model/otp_code_no_sql_model.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"time"
+
+	"github.com/amorindev/go-cms-tmpl/pkg/features/opt-codes/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type OtpCodeNoSqlModel struct {
+	ID        bson.ObjectID         `bson:"_id"`
+	UserID    bson.ObjectID         `bson:"user_id"`
+	OptCode   string                `bson:"otp_code"`
+	Purpose   domain.OtpCodePurpose `bson:"purpose"`
+	Used      bool                  `bson:"used"`
+	ExpiresAt *time.Time            `bson:"expires_at"`
+	CreatedAt *time.Time            `bson:"created_at"`
+}
+
+func (m *OtpCodeNoSqlModel) ToDomain(o *domain.OtpCode) {
+	if m == nil {
+		return
+	}
+
+	o.ID = m.ID.Hex()
+	o.UserID = m.UserID.Hex()
+	o.OptCode = m.OptCode
+	o.Purpose = m.Purpose
+	o.Used = m.Used
+	o.ExpiresAt = m.ExpiresAt
+	o.CreatedAt = m.CreatedAt
+}
+
+func FromDomain(o *domain.OtpCode, id bson.ObjectID) (*OtpCodeNoSqlModel, error) {
+	if o == nil {
+		return nil, nil
+	}
+
+	userObjectID, err := bson.ObjectIDFromHex(o.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &OtpCodeNoSqlModel{
+		ID:        id,
+		UserID:    userObjectID,
+		OptCode:   o.OptCode,
+		Purpose:   o.Purpose,
+		Used:      o.Used,
+		ExpiresAt: o.ExpiresAt,
+		CreatedAt: o.CreatedAt,
+	}, nil
+}

--- a/pkg/features/opt-codes/repository/mongo/find.go
+++ b/pkg/features/opt-codes/repository/mongo/find.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/opt-codes/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/opt-codes/model"
 	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -26,8 +27,8 @@ func (r *Repository) Find(ctx context.Context, id, userID string) (*domain.OtpCo
 		{Key: "user_id", Value: userOID},
 	}
 
-	var otp domain.OtpCode
-	err = r.Collection.FindOne(ctx, filter).Decode(&otp)
+	var otpCodeModel model.OtpCodeNoSqlModel
+	err = r.Collection.FindOne(ctx, filter).Decode(&otpCodeModel)
 	if err != nil {
 		if err == mongo.ErrNoDocuments {
 			return nil, fmt.Errorf("%w: otp with id %s not found: %w", sharedD.ErrNotFound, id, err)
@@ -35,8 +36,9 @@ func (r *Repository) Find(ctx context.Context, id, userID string) (*domain.OtpCo
 		return nil, fmt.Errorf("error getting otpCode: %w", err)
 	}
 
-	otp.ID = oID.Hex()
-	otp.UserID = userOID.Hex()
+	
+	var otpCode domain.OtpCode
+	otpCodeModel.ToDomain(&otpCode)
 
-	return &otp, nil
+	return &otpCode, nil
 }

--- a/pkg/features/opt-codes/repository/mongo/insert.go
+++ b/pkg/features/opt-codes/repository/mongo/insert.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/amorindev/go-cms-tmpl/pkg/features/opt-codes/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/features/opt-codes/model"
 	dShared "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -12,16 +13,13 @@ import (
 
 func (r *Repository) Insert(ctx context.Context, otp *domain.OtpCode) error {
 	id := bson.NewObjectID()
-	otp.ID = id
 
-	userOID, err := bson.ObjectIDFromHex(otp.UserID.(string))
+	optCodeModel, err := model.FromDomain(otp, id)
 	if err != nil {
-		return dShared.ErrIncorrectID
+		return fmt.Errorf("error mapping otpCode to mongo model: %w", err)
 	}
 
-	otp.UserID = userOID
-
-	_, err = r.Collection.InsertOne(ctx, otp)
+	_, err = r.Collection.InsertOne(ctx, optCodeModel)
 	if err != nil {
 		if mongo.IsDuplicateKeyError(err) {
 			return fmt.Errorf("%w: error inserting opt code: %w", dShared.ErrDuplicateKey, err)
@@ -29,8 +27,7 @@ func (r *Repository) Insert(ctx context.Context, otp *domain.OtpCode) error {
 		return fmt.Errorf("error inserting otp code: %w", err)
 	}
 
-	otp.ID = id.Hex()
-	otp.UserID = userOID.Hex()
+	optCodeModel.ToDomain(otp)
 
 	return nil
 }


### PR DESCRIPTION
### Tasks
- Replace interface{} IDs with string in OtpCode domain
- Remove BSON tags from domain entity
- Introduce OtpCodeNoSqlModel for MongoDB mapping
- Move ObjectID conversion logic to repository layer
- Remove type assertions and unsafe ID casting
- Fully decouple OTP domain from MongoDB concerns