### PR TITLE
feat #11 (identity): add roles and permissions to access token and session flows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,12 @@ build:
 	go build -o app.exe cmd/api/env/dev/main.go
 	.\app.exe
 
+
+# Run all tests recursively.
+# Only `go test ./...` is required.
+# `findstr` is used on Windows to hide "[no test files]" lines.
+test:
+	go test ./... | findstr /v "[no test files]"
+
 compose-dev:
 	@docker-compose -f docker-compose.dev.yml --env-file .env up

--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -132,11 +132,11 @@ func New() http.Handler {
 	sessionSrv := sessionService.NewSessionSrv(sessionRepo, tokenSrv)
 	otpCodeSrv := otpCodeService.NewOtpCodeSrv(otpCodeRepo)
 	mailerSrv := mailerService.NewMailerSrv(mailerAdt, appEnvs.AppName)
-	authSrv := authService.NewAuthSrv(userRepo, userFileStg, sessionSrv, otpCodeSrv, mailerSrv)
+	authSrv := authService.NewAuthSrv(userRepo, roleRepo,permissionRepo,userFileStg,sessionSrv, otpCodeSrv, mailerSrv)
 	userSrv := userService.NewUserSrv(userRepo, userFileStg)
 
 	// service - admin
-	adminSrv := adminService.NewAdminSrv(userRepo, roleRepo, sessionSrv)
+	adminSrv := adminService.NewAdminSrv(userRepo, roleRepo, permissionRepo,sessionSrv)
 
 	// Handler
 	// Note: all subsequent handlers should also be registered using v1

--- a/pkg/identity/admin/service/service.go
+++ b/pkg/identity/admin/service/service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	adminP "github.com/amorindev/go-cms-tmpl/pkg/identity/admin/port"
+	permissionP "github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/port"
 	roleP "github.com/amorindev/go-cms-tmpl/pkg/identity/roles/port"
 	sessionP "github.com/amorindev/go-cms-tmpl/pkg/identity/session/port"
 	userP "github.com/amorindev/go-cms-tmpl/pkg/identity/users/port"
@@ -10,15 +11,17 @@ import (
 var _ adminP.AdminSrv = &Service{}
 
 type Service struct {
-	UserRepo   userP.UserRepo
-	RoleRepo   roleP.RoleRepo
-	SessionSrv sessionP.SessionSrv
+	UserRepo       userP.UserRepo
+	RoleRepo       roleP.RoleRepo
+	PermissionRepo permissionP.PermissionRepo
+	SessionSrv     sessionP.SessionSrv
 }
 
-func NewAdminSrv(userRepo userP.UserRepo, roleRepo roleP.RoleRepo, sessionSrv sessionP.SessionSrv) *Service {
+func NewAdminSrv(userRepo userP.UserRepo, roleRepo roleP.RoleRepo, permissionRepo permissionP.PermissionRepo, sessionSrv sessionP.SessionSrv) *Service {
 	return &Service{
-		UserRepo:   userRepo,
-		RoleRepo:   roleRepo,
-		SessionSrv: sessionSrv,
+		UserRepo:       userRepo,
+		RoleRepo:       roleRepo,
+		PermissionRepo: permissionRepo,
+		SessionSrv:     sessionSrv,
 	}
 }

--- a/pkg/identity/admin/service/sign_in.go
+++ b/pkg/identity/admin/service/sign_in.go
@@ -6,31 +6,69 @@ import (
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/encryption"
 	sessionD "github.com/amorindev/go-cms-tmpl/pkg/identity/session/domain"
 	userD "github.com/amorindev/go-cms-tmpl/pkg/identity/users/domain"
-	sharedDomain "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
+	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 )
 
 func (s *Service) SignIn(ctx context.Context, email string, password string, rememberMe bool) (*userD.User, *sessionD.Session, error) {
 	// Verify if user exists
 	user, err := s.UserRepo.FindByEmail(ctx, email)
 	if err != nil {
-		return nil, nil, sharedDomain.ManageError(sharedDomain.ErrInvalidCredentials, "")
+		return nil, nil, sharedD.ManageError(sharedD.ErrInvalidCredentials, "")
 	}
 
 	if !user.IsActive {
-		return nil, nil, sharedDomain.ManageError(sharedDomain.ErrAccountInactive, "")
+		return nil, nil, sharedD.ManageError(sharedD.ErrAccountInactive, "")
 	}
 
 	err = encryption.CheckPassword(password, user.UserPassAuth.PasswordHash)
 	if err != nil {
-		return nil, nil, sharedDomain.ManageError(sharedDomain.ErrInvalidCredentials, "")
+		return nil, nil, sharedD.ManageError(sharedD.ErrInvalidCredentials, "")
+	}
+
+	// get Roles
+	roles, err := s.RoleRepo.FindByIDs(ctx, user.RoleIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	roleNames := make([]string, 0, len(roles))
+
+	// Collect all permission IDs, no duplicates
+	permissionIDMap := make(map[string]struct{})
+
+	for _, role := range roles {
+		for _, pid := range role.PermissionIDs {
+			permissionIDMap[pid] = struct{}{}
+		}
+		roleNames = append(roleNames, role.Name)
+
+	}
+
+	// From the previous one we get "{"read_users": {},"write_users": {},"export_users": {}}",
+	// now we convert it to a slice
+	var permissionIDs []string
+	for id := range permissionIDMap {
+		permissionIDs = append(permissionIDs, id)
+	}
+
+	// Get permissions
+	permissions, err := s.PermissionRepo.FindByIDs(ctx, permissionIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	permissionNames := make([]string, 0, len(permissions))
+
+	for _, p := range permissions {
+		permissionNames = append(permissionNames, p.Name)
 	}
 
 	// Create session
 	session := sessionD.NewSession(user.ID, rememberMe)
 
-	err = s.SessionSrv.Create(ctx, session, nil, email)
+	err = s.SessionSrv.Create(ctx, session, roleNames, permissionNames, email)
 	if err != nil {
-		return nil, nil, sharedDomain.ManageError(sharedDomain.ErrInvalidCredentials, "")
+		return nil, nil, sharedD.ManageError(sharedD.ErrInvalidCredentials, "")
 	}
 
 	user.UserPassAuth = nil

--- a/pkg/identity/auth/service/get_session.go
+++ b/pkg/identity/auth/service/get_session.go
@@ -8,21 +8,22 @@ import (
 	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 )
 
-func (s *Service) GetSession(ctx context.Context, rTokenID string, userID string) (*userD.User,*sessionD.Session, error) {
+func (s *Service) GetSession(ctx context.Context, rTokenID string, userID string) (*userD.User, *sessionD.Session, error) {
 	session, err := s.SessionSrv.GetByRTokenID(ctx, rTokenID, userID)
 	if err != nil {
-		return nil,nil, sharedD.ManageError(err, "")
+		return nil, nil, sharedD.ManageError(err, "")
 	}
 
 	if session.Revoked {
-		return nil,nil, sharedD.ManageError(err, "")
+		return nil, nil, sharedD.ManageError(err, "")
 	}
 
 	user, err := s.UserRepo.Find(ctx, userID)
 	if err != nil {
-		return nil,nil, sharedD.ManageError(err, "")
+		return nil, nil, sharedD.ManageError(err, "")
 	}
-    // If the user has an image path, retrieve the image URL and set it
+
+	// If the user has an image path, retrieve the image URL and set it
 	if user.ImgPath != nil {
 		url, err := s.UserFileStg.GetImage(ctx, *user.ImgPath)
 		if err != nil {
@@ -31,15 +32,53 @@ func (s *Service) GetSession(ctx context.Context, rTokenID string, userID string
 		user.ImgUrl = &url
 	}
 
+	// get Roles
+	roles, err := s.RoleRepo.FindByIDs(ctx, user.RoleIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	roleNames := make([]string, 0, len(roles))
+
+	// Collect all permission IDs, no duplicates
+	permissionIDMap := make(map[string]struct{})
+
+	for _, role := range roles {
+		for _, pid := range role.PermissionIDs {
+			permissionIDMap[pid] = struct{}{}
+		}
+		roleNames = append(roleNames, role.Name)
+
+	}
+
+	// From the previous one we get "{"read_users": {},"write_users": {},"export_users": {}}",
+	// now we convert it to a slice
+	var permissionIDs []string
+	for id := range permissionIDMap {
+		permissionIDs = append(permissionIDs, id)
+	}
+
+	// Get permissions
+	permissions, err := s.PermissionRepo.FindByIDs(ctx, permissionIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	permissionNames := make([]string, 0, len(permissions))
+
+	for _, p := range permissions {
+		permissionNames = append(permissionNames, p.Name)
+	}
+
 	// Create session
 	newSession := sessionD.NewSession(user.ID, session.RememberMe)
 
-	err = s.SessionSrv.Create(ctx, newSession, nil, user.Email)
+	err = s.SessionSrv.Create(ctx, newSession, roleNames, permissionNames, user.Email)
 	if err != nil {
-		return nil, nil,sharedD.ManageError(err, "")
+		return nil, nil, sharedD.ManageError(err, "")
 	}
 
 	user.UserPassAuth = nil
 
-	return user,newSession, nil
+	return user, newSession, nil
 }

--- a/pkg/identity/auth/service/refresh_token.go
+++ b/pkg/identity/auth/service/refresh_token.go
@@ -28,10 +28,48 @@ func (s *Service) RefreshToken(ctx context.Context, rTokenID string, userID stri
 		return nil, sharedD.ManageError(err, "")
 	}
 
+	// get Roles
+	roles, err := s.RoleRepo.FindByIDs(ctx, user.RoleIDs)
+	if err != nil {
+		return nil, sharedD.ManageError(err, "")
+	}
+
+	roleNames := make([]string, 0, len(roles))
+
+	// Collect all permission IDs, no duplicates
+	permissionIDMap := make(map[string]struct{})
+
+	for _, role := range roles {
+		for _, pid := range role.PermissionIDs {
+			permissionIDMap[pid] = struct{}{}
+		}
+		roleNames = append(roleNames, role.Name)
+
+	}
+
+	// From the previous one we get "{"read_users": {},"write_users": {},"export_users": {}}",
+	// now we convert it to a slice
+	var permissionIDs []string
+	for id := range permissionIDMap {
+		permissionIDs = append(permissionIDs, id)
+	}
+
+	// Get permissions
+	permissions, err := s.PermissionRepo.FindByIDs(ctx, permissionIDs)
+	if err != nil {
+		return nil, sharedD.ManageError(err, "")
+	}
+
+	permissionNames := make([]string, 0, len(permissions))
+
+	for _, p := range permissions {
+		permissionNames = append(permissionNames, p.Name)
+	}
+
 	// Create session
 	newSession := sessionD.NewSession(user.ID, session.RememberMe)
 
-	err = s.SessionSrv.Create(ctx, newSession, nil, user.Email)
+	err = s.SessionSrv.Create(ctx, newSession, roleNames,permissionNames, user.Email)
 	if err != nil {
 		return nil, sharedD.ManageError(err, "")
 	}

--- a/pkg/identity/auth/service/service.go
+++ b/pkg/identity/auth/service/service.go
@@ -4,6 +4,8 @@ import (
 	authP "github.com/amorindev/go-cms-tmpl/pkg/identity/auth/port"
 	mailerP "github.com/amorindev/go-cms-tmpl/pkg/identity/mailer/port"
 	otpCodeP "github.com/amorindev/go-cms-tmpl/pkg/identity/opt-codes/port"
+	permissionP "github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/port"
+	roleP "github.com/amorindev/go-cms-tmpl/pkg/identity/roles/port"
 	sessionP "github.com/amorindev/go-cms-tmpl/pkg/identity/session/port"
 	userP "github.com/amorindev/go-cms-tmpl/pkg/identity/users/port"
 )
@@ -11,19 +13,23 @@ import (
 var _ authP.AuthSrv = &Service{}
 
 type Service struct {
-	UserRepo    userP.UserRepo
-	UserFileStg userP.UserFileStg
-	SessionSrv  sessionP.SessionSrv
-	OtpCodeSrv  otpCodeP.OtpCodeSrv
-	MailerSrv   mailerP.MailerSrv
+	UserRepo       userP.UserRepo
+	RoleRepo       roleP.RoleRepo
+	PermissionRepo permissionP.PermissionRepo
+	UserFileStg    userP.UserFileStg
+	SessionSrv     sessionP.SessionSrv
+	OtpCodeSrv     otpCodeP.OtpCodeSrv
+	MailerSrv      mailerP.MailerSrv
 }
 
-func NewAuthSrv(userRepo userP.UserRepo, userFileStg userP.UserFileStg, sessionSrv sessionP.SessionSrv, otpCodeSrv otpCodeP.OtpCodeSrv, mailerSrv mailerP.MailerSrv) *Service {
+func NewAuthSrv(userRepo userP.UserRepo, roleRepo roleP.RoleRepo, permissionRepo permissionP.PermissionRepo, userFileStg userP.UserFileStg, sessionSrv sessionP.SessionSrv, otpCodeSrv otpCodeP.OtpCodeSrv, mailerSrv mailerP.MailerSrv) *Service {
 	return &Service{
-		UserRepo:    userRepo,
-		UserFileStg: userFileStg,
-		SessionSrv:  sessionSrv,
-		OtpCodeSrv:  otpCodeSrv,
-		MailerSrv:   mailerSrv,
+		UserRepo:       userRepo,
+		RoleRepo:       roleRepo,
+		PermissionRepo: permissionRepo,
+		UserFileStg:    userFileStg,
+		SessionSrv:     sessionSrv,
+		OtpCodeSrv:     otpCodeSrv,
+		MailerSrv:      mailerSrv,
 	}
 }

--- a/pkg/identity/auth/service/sign_in.go
+++ b/pkg/identity/auth/service/sign_in.go
@@ -8,7 +8,7 @@ import (
 	otpCodeD "github.com/amorindev/go-cms-tmpl/pkg/identity/opt-codes/domain"
 	sessionD "github.com/amorindev/go-cms-tmpl/pkg/identity/session/domain"
 	userD "github.com/amorindev/go-cms-tmpl/pkg/identity/users/domain"
-	dShared "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
+	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	sharedDomain "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 )
 
@@ -16,23 +16,23 @@ func (s *Service) SignIn(ctx context.Context, email string, password string, rem
 	// Verify if user exists
 	user, err := s.UserRepo.FindByEmail(ctx, email)
 	if err != nil {
-		return nil, nil, "", dShared.ManageError(err, "")
+		return nil, nil, "", sharedD.ManageError(err, "")
 	}
 
 	if !user.IsActive {
-		return nil, nil, "", dShared.ManageError(dShared.ErrAccountInactive, "")
+		return nil, nil, "", sharedD.ManageError(sharedD.ErrAccountInactive, "")
 	}
 
 	err = encryption.CheckPassword(password, user.UserPassAuth.PasswordHash)
 	if err != nil {
-		return nil, nil, "", dShared.ManageError(err, "")
+		return nil, nil, "", sharedD.ManageError(err, "")
 	}
 
 	// If the user has an image path, retrieve the image URL and set it
 	if user.ImgPath != nil {
 		url, err := s.UserFileStg.GetImage(ctx, *user.ImgPath)
 		if err != nil {
-			return nil, nil, "", dShared.ManageError(err, "")
+			return nil, nil, "", sharedD.ManageError(err, "")
 		}
 		user.ImgUrl = &url
 	}
@@ -60,17 +60,55 @@ func (s *Service) SignIn(ctx context.Context, email string, password string, rem
 		// Send the verification email to the user with the OTP code
 		err = s.MailerSrv.SendVerifyEmail(user.Email, otp.OptCode)
 		if err != nil {
-			return nil, nil, "", dShared.ManageError(err, "")
+			return nil, nil, "", sharedD.ManageError(err, "")
 		}
 		return user, nil, otp.ID, nil
+	}
+
+	// get Roles
+	roles, err := s.RoleRepo.FindByIDs(ctx, user.RoleIDs)
+	if err != nil {
+		return nil, nil, "",sharedD.ManageError(err, "")
+	}
+
+	roleNames := make([]string, 0, len(roles))
+
+	// Collect all permission IDs, no duplicates
+	permissionIDMap := make(map[string]struct{})
+
+	for _, role := range roles {
+		for _, pid := range role.PermissionIDs {
+			permissionIDMap[pid] = struct{}{}
+		}
+		roleNames = append(roleNames, role.Name)
+
+	}
+
+	// From the previous one we get "{"read_users": {},"write_users": {},"export_users": {}}",
+	// now we convert it to a slice
+	var permissionIDs []string
+	for id := range permissionIDMap {
+		permissionIDs = append(permissionIDs, id)
+	}
+
+	// Get permissions
+	permissions, err := s.PermissionRepo.FindByIDs(ctx, permissionIDs)
+	if err != nil {
+		return nil, nil, "",sharedD.ManageError(err, "")
+	}
+
+	permissionNames := make([]string, 0, len(permissions))
+
+	for _, p := range permissions {
+		permissionNames = append(permissionNames, p.Name)
 	}
 
 	// Create session
 	session := sessionD.NewSession(user.ID, rememberMe)
 
-	err = s.SessionSrv.Create(ctx, session, nil, email)
+	err = s.SessionSrv.Create(ctx, session, roleNames,permissionNames, email)
 	if err != nil {
-		return nil, nil, "", dShared.ManageError(err, "")
+		return nil, nil, "", sharedD.ManageError(err, "")
 	}
 
 	user.UserPassAuth = nil

--- a/pkg/identity/auth/service/verify_email.go
+++ b/pkg/identity/auth/service/verify_email.go
@@ -47,12 +47,50 @@ func (s *Service) VerifyEmail(ctx context.Context, otpID string, otpCode string,
 		user.ImgUrl = &url
 	}
 
+	// get Roles
+	roles, err := s.RoleRepo.FindByIDs(ctx, user.RoleIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	roleNames := make([]string, 0, len(roles))
+
+	// Collect all permission IDs, no duplicates
+	permissionIDMap := make(map[string]struct{})
+
+	for _, role := range roles {
+		for _, pid := range role.PermissionIDs {
+			permissionIDMap[pid] = struct{}{}
+		}
+		roleNames = append(roleNames, role.Name)
+
+	}
+
+	// From the previous one we get "{"read_users": {},"write_users": {},"export_users": {}}",
+	// now we convert it to a slice
+	var permissionIDs []string
+	for id := range permissionIDMap {
+		permissionIDs = append(permissionIDs, id)
+	}
+
+	// Get permissions
+	permissions, err := s.PermissionRepo.FindByIDs(ctx, permissionIDs)
+	if err != nil {
+		return nil, nil, sharedD.ManageError(err, "")
+	}
+
+	permissionNames := make([]string, 0, len(permissions))
+
+	for _, p := range permissions {
+		permissionNames = append(permissionNames, p.Name)
+	}
+
 	session := &sessionD.Session{
 		UserID:     user.ID,
 		RememberMe: false,
 	}
 
-	err = s.SessionSrv.Create(ctx, session, nil, user.Email)
+	err = s.SessionSrv.Create(ctx, session, roleNames, permissionNames, user.Email)
 	if err != nil {
 		return nil, nil, sharedD.ManageError(err, "failed to create user session")
 	}

--- a/pkg/identity/permissions/port/port.go
+++ b/pkg/identity/permissions/port/port.go
@@ -15,4 +15,5 @@ type PermissionRepo interface {
 	Insert(ctx context.Context, permission *domain.Permission) error
 	Exists(ctx context.Context, name domain.PermissionName) (bool, error)
 	FindByNames(ctx context.Context, names []domain.PermissionName) ([]*domain.Permission, error)
+	FindByIDs(ctx context.Context, permissionsIDs []string) ([]*domain.Permission, error)
 }

--- a/pkg/identity/permissions/repository/mongo/find_by_ids.go
+++ b/pkg/identity/permissions/repository/mongo/find_by_ids.go
@@ -1,0 +1,58 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/model"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// FindByIDs returns the permissions for the given permission IDs.
+//
+// This function is typically used after resolving roles that contain a list
+// of permission IDs. It queries the database for those permission documents
+// and returns the full Permission domain entities. If no IDs are provided,
+// it returns an empty slice.
+func (r *Repository) FindByIDs(ctx context.Context, permissionIDs []string) ([]*domain.Permission, error) {
+	if len(permissionIDs) == 0 {
+		return []*domain.Permission{}, nil
+	}
+
+	var permissionOIDs []bson.ObjectID
+	for _, id := range permissionIDs {
+		oID, err := bson.ObjectIDFromHex(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid permission ID format (%s): %w", id, err)
+		}
+		permissionOIDs = append(permissionOIDs, oID)
+	}
+
+	filter := bson.M{"_id": bson.M{"$in": permissionOIDs}}
+
+	cursor, err := r.Collection.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error getting permissions by IDs: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var permissions []*domain.Permission
+	for cursor.Next(ctx) {
+		var permissionModel model.PermissionNoSqlModel
+		if err := cursor.Decode(&permissionModel); err != nil {
+			return nil, fmt.Errorf("error decoding permission document: %w", err)
+		}
+
+		var permission domain.Permission
+		permissionModel.ToDomain(&permission)
+
+		permissions = append(permissions, &permission)
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("cursor error while iterating permissions documents: %w", err)
+	}
+
+	return permissions, nil
+}

--- a/pkg/identity/roles/domain/domain.go
+++ b/pkg/identity/roles/domain/domain.go
@@ -1,9 +1,9 @@
 package domain
 
 type Role struct {
-	ID            string   `json:"id" bson:"_id"`
-	Name          string        `json:"name" bson:"name"`
-	PermissionIDs []string `bson:"permission_ids"`
+	ID            string   `json:"id"`
+	Name          string   `json:"name"`
+	PermissionIDs []string 
 }
 
 // Initialize PermissionIDs as an empty slice to allow MongoDB $addToSet operations.

--- a/pkg/identity/roles/port/port.go
+++ b/pkg/identity/roles/port/port.go
@@ -11,4 +11,5 @@ type RoleRepo interface {
 	Exists(ctx context.Context, name string) (bool, error)
 	FindByName(ctx context.Context, name string) (*domain.Role, error)
 	AssignPermissions(ctx context.Context, name string, permissionIDs []string) error
+	FindByIDs(ctx context.Context, roleIDs []string) ([]*domain.Role, error)
 }

--- a/pkg/identity/roles/repository/mongo/find_by_ids.go
+++ b/pkg/identity/roles/repository/mongo/find_by_ids.go
@@ -1,0 +1,58 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/roles/domain"
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/roles/model"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+// FindByIDs returns the roles for the given role IDs.
+//
+// This function is used during the sign-in process: after retrieving a user
+// that contains a list of role IDs, it queries the database for those role
+// documents and returns the full Role entities. If no IDs are provided,
+// it returns an empty slice.
+func (r *Repository) FindByIDs(ctx context.Context, roleIDs []string) ([]*domain.Role, error) {
+	if len(roleIDs) == 0 {
+		return []*domain.Role{}, nil
+	}
+
+	var roleOIDs []bson.ObjectID
+	for _, id := range roleIDs {
+		oID, err := bson.ObjectIDFromHex(id)
+		if err != nil {
+			return nil, fmt.Errorf("invalid role ID format (%s): %w", id, err)
+		}
+		roleOIDs = append(roleOIDs, oID)
+	}
+
+	filter := bson.M{"_id": bson.M{"$in": roleOIDs}}
+
+	cursor, err := r.Collection.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("error getting roles by IDs: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var roles []*domain.Role
+	for cursor.Next(ctx) {
+		var roleModel model.RoleNoSqlModel
+		if err := cursor.Decode(&roleModel); err != nil {
+			return nil, fmt.Errorf("error decoding role document: %w", err)
+		}
+
+		var role domain.Role
+		roleModel.ToDomain(&role)
+
+		roles = append(roles, &role)
+	}
+
+	if err := cursor.Err(); err != nil {
+		return nil, fmt.Errorf("cursor error while iterating roles documents: %w", err)
+	}
+
+	return roles, nil
+}

--- a/pkg/identity/session/port/ports.go
+++ b/pkg/identity/session/port/ports.go
@@ -13,7 +13,7 @@ type SessionRepo interface {
 }
 
 type SessionSrv interface {
-	Create(ctx context.Context, session *domain.Session, roles []string, email string) error
+	Create(ctx context.Context, session *domain.Session, roles []string, permissions []string, email string) error
 	DeleteByRTokenID(ctx context.Context, rTokenID string) error
 	GetByRTokenID(ctx context.Context, rTokenID, userID string) (*domain.Session, error)
 }

--- a/pkg/identity/session/service/create.go
+++ b/pkg/identity/session/service/create.go
@@ -7,9 +7,9 @@ import (
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/session/domain"
 )
 
-func (s *Service) Create(ctx context.Context, session *domain.Session, roles []string, email string) error {
+func (s *Service) Create(ctx context.Context, session *domain.Session, roles []string, permissions []string, email string) error {
 	// Create access token
-	aToken, aTokenExpIn, err := s.TokenSrv.CreateAccessToken(session.UserID, email, roles)
+	aToken, aTokenExpIn, err := s.TokenSrv.CreateAccessToken(session.UserID, email, roles, permissions)
 	if err != nil {
 		return err
 	}

--- a/pkg/identity/tokens/claim/access_token.go
+++ b/pkg/identity/tokens/claim/access_token.go
@@ -11,18 +11,20 @@ import (
 
 // AccessTokenClaims defines the payload for the access token
 type AccessTokenClaims struct {
-	UserID string   `json:"user_id"`
-	Email  string   `json:"email"`
-	Roles  []string `json:"role,omitempty"`
+	UserID      string   `json:"user_id"`
+	Email       string   `json:"email"`
+	Roles       []string `json:"role,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
 	jwt.RegisteredClaims
 }
 
 // NewAccessTokenClaim creates a new set of claims for an access token
-func NewAccessTokenClaim(userID string, email string, issuer string, roles []string, expiresIn time.Duration) *AccessTokenClaims {
+func NewAccessTokenClaim(userID string, email string, issuer string, roles []string, permissions []string, expiresIn time.Duration) *AccessTokenClaims {
 	return &AccessTokenClaims{
 		UserID: userID,
 		Email:  email,
 		Roles:  roles,
+		Permissions: permissions,
 		RegisteredClaims: jwt.RegisteredClaims{
 			Subject:   userID,
 			Issuer:    issuer,

--- a/pkg/identity/tokens/port/ports.go
+++ b/pkg/identity/tokens/port/ports.go
@@ -3,7 +3,7 @@ package port
 import "github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/claim"
 
 type TokenSrv interface {
-	CreateAccessToken(userID string, email string, roles []string) (string, int64, error)
+	CreateAccessToken(userID string, email string, roles []string, permissions []string) (string, int64, error)
 	CreateRefreshToken(userID string, rememberMe bool) (string, string, int64, error)
 	ParseAccessToken(tokenStr string) (*claim.AccessTokenClaims, error)
 	ParseRefreshToken(tokenStr string) (*claim.RefreshTokenClaims, error)

--- a/pkg/identity/tokens/service/access_token.go
+++ b/pkg/identity/tokens/service/access_token.go
@@ -3,8 +3,8 @@ package service
 import "github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/claim"
 
 // CreateAccessToken generates a signed access token
-func (ts *Service) CreateAccessToken(userID string, email string, roles []string) (string, int64, error) {
-	claims := claim.NewAccessTokenClaim(userID, email, ts.Issuer, roles, ts.AccessExpiresIn)
+func (ts *Service) CreateAccessToken(userID string, email string, roles []string, permissions []string) (string, int64, error) {
+	claims := claim.NewAccessTokenClaim(userID, email, ts.Issuer, roles, permissions, ts.AccessExpiresIn)
 	token, err := claims.GetToken(ts.AccessSecret)
 	if err != nil {
 		return "", 0, err

--- a/pkg/identity/tokens/service/create_access_token_test.go
+++ b/pkg/identity/tokens/service/create_access_token_test.go
@@ -4,35 +4,38 @@ import (
 	"testing"
 	"time"
 
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/domain"
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/service"
 	"github.com/stretchr/testify/require"
 )
-
 
 func TestService_CreateAccessToken(t *testing.T) {
 
 	s := service.NewTokenSrv("a_secret", "r_secret", time.Minute, time.Hour, 24*time.Minute, "my-app")
 
 	testTable := map[string]struct {
-		userID string
-		email  string
-		roles  []string
+		userID      string
+		email       string
+		roles       []string
+		permissions []string
 	}{
 		"success": {
-			userID: "123",
-			email:  "user@example.com",
-			roles:  []string{"User"},
+			userID:      "123",
+			email:       "user@example.com",
+			roles:       []string{"User"},
+			permissions: []string{string(domain.PAdminAccess)},
 		},
-		"success without roles": {
-			userID: "123",
-			email:  "user@example.com",
-			roles:  nil,
+		"success without roles and permissions": {
+			userID:      "123",
+			email:       "user@example.com",
+			roles:       nil,
+			permissions: nil,
 		},
 	}
 
 	for testName, test := range testTable {
 		t.Run(testName, func(subTest *testing.T) {
-			gotToken, gotExp, gotErr := s.CreateAccessToken(test.userID, test.email, test.roles)
+			gotToken, gotExp, gotErr := s.CreateAccessToken(test.userID, test.email, test.permissions, test.roles)
 			require.NoError(subTest, gotErr)
 			require.NotEmpty(subTest, gotToken)
 			require.Equal(subTest, int64(s.AccessExpiresIn.Seconds()), gotExp)

--- a/pkg/identity/tokens/service/parse_access_token_test.go
+++ b/pkg/identity/tokens/service/parse_access_token_test.go
@@ -1,13 +1,15 @@
 package service_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/amorindev/go-cms-tmpl/pkg/identity/permissions/domain"
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/claim"
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/port"
 	"github.com/amorindev/go-cms-tmpl/pkg/identity/tokens/service"
-	"github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
+	sharedD "github.com/amorindev/go-cms-tmpl/pkg/shared/domain"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/require"
 )
@@ -21,7 +23,7 @@ func TestService_ParseAccessToken(t *testing.T) {
 	}{
 		"success": {
 			setup: func() (port.TokenSrv, string) {
-				token, _, err := sharedSrv.CreateAccessToken("123", "user@example.com", []string{"User"})
+				token, _, err := sharedSrv.CreateAccessToken("123", "user@example.com", []string{"User"}, []string{string(domain.PAdminAccess)})
 				require.NoError(t, err)
 				return sharedSrv, token
 			},
@@ -30,6 +32,10 @@ func TestService_ParseAccessToken(t *testing.T) {
 				require.Equal(subTest, "123", gotClaims.UserID)
 				require.Equal(subTest, "user@example.com", gotClaims.Email)
 				require.Contains(subTest, gotClaims.Roles, "User")
+				fmt.Println("----------------------")
+				fmt.Println(gotClaims.Permissions)
+				fmt.Println("----------------------")
+				require.Contains(subTest, gotClaims.Permissions, string(domain.PAdminAccess))
 				require.Equal(subTest, "my-app", gotClaims.Issuer)
 				require.Equal(subTest, "123", gotClaims.Subject)
 			},
@@ -37,7 +43,7 @@ func TestService_ParseAccessToken(t *testing.T) {
 		"expired token": {
 			setup: func() (port.TokenSrv, string) {
 				shortS := service.NewTokenSrv("a_secret", "r_secret", 1*time.Second, 1*time.Second, 1*time.Second, "my-app")
-				token, _, err := shortS.CreateAccessToken("123", "user@example.com", []string{"User"})
+				token, _, err := shortS.CreateAccessToken("123", "user@example.com", []string{"User"}, []string{string(domain.PAdminAccess)})
 				require.NoError(t, err)
 
 				time.Sleep(2 * time.Second)
@@ -46,20 +52,20 @@ func TestService_ParseAccessToken(t *testing.T) {
 			assertionFunc: func(subTest *testing.T, gotClaims *claim.AccessTokenClaims, gotErr error) {
 				require.Nil(subTest, gotClaims)
 				require.Error(subTest, gotErr)
-				require.ErrorIs(subTest, domain.ErrTokenExpired, gotErr)
+				require.ErrorIs(subTest, sharedD.ErrTokenExpired, gotErr)
 			},
 		},
 		"invalid signature": {
 			setup: func() (port.TokenSrv, string) {
 				badSrv := service.NewTokenSrv("a_wrong", "r_secret", time.Minute, time.Hour, 24*time.Minute, "my-app")
-				token, _, err := badSrv.CreateAccessToken("123", "user@example.com", []string{"User"})
+				token, _, err := badSrv.CreateAccessToken("123", "user@example.com", []string{"User"}, []string{string(domain.PAdminAccess)})
 				require.NoError(t, err)
 				return sharedSrv, token
 			},
 			assertionFunc: func(subTest *testing.T, gotClaims *claim.AccessTokenClaims, gotErr error) {
 				require.Nil(subTest, gotClaims)
 				require.Error(subTest, gotErr)
-				require.ErrorIs(subTest, domain.ErrTokenSignature, gotErr)
+				require.ErrorIs(subTest, sharedD.ErrTokenSignature, gotErr)
 			},
 		},
 		"malformed token or empty": {
@@ -69,13 +75,13 @@ func TestService_ParseAccessToken(t *testing.T) {
 			assertionFunc: func(subTest *testing.T, gotClaims *claim.AccessTokenClaims, gotErr error) {
 				require.Nil(subTest, gotClaims)
 				require.Error(subTest, gotErr)
-				require.ErrorIs(subTest, domain.ErrTokenMalformed, gotErr)
+				require.ErrorIs(subTest, sharedD.ErrTokenMalformed, gotErr)
 			},
 		},
 		"token not valid (nbf)": {
 			setup: func() (port.TokenSrv, string) {
 				c := claim.NewAccessTokenClaim("123", "user@example.com", "my-app",
-					[]string{"User"}, time.Minute)
+					[]string{"User"}, []string{string(domain.PAdminAccess)}, time.Minute)
 				// Force the NotBefore (nbf) field to one hour in the future.
 				// The token should not be considered valid until that time.
 				c.NotBefore = jwt.NewNumericDate(time.Now().Add(time.Hour))


### PR DESCRIPTION
### Tasks
- Added Permissions field to AccessTokenClaims
- Updated NewAccessTokenClaim to include permissions
- Extended session-related use cases (sign-in, refresh-token, verify-email, get-session) to return roles and permissions
- Updated ports and repository implementations accordingly

### Test
<img width="1277" height="82" alt="image" src="https://github.com/user-attachments/assets/1c675b44-6f9d-4a69-985b-72a4a143ed66" />

### The administrator user has the primary role and all permissions
<img width="2509" height="1245" alt="image" src="https://github.com/user-attachments/assets/10b57365-4bc3-4764-8c26-5c2c0d8b1e4d" />

### The user has no roles or permissions
<img width="2540" height="1084" alt="image" src="https://github.com/user-attachments/assets/c1fac89b-ca7b-43b2-9bcb-1e30ef837ff9" />

Close #11 
