### PR TITLE
feat #36 (posts): add post search functionality with MongoDB text index

### DIFF
--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -13,7 +13,9 @@ import (
 	resendClient "github.com/GoEnterpricePlatform/goEP-core/internal/resend"
 	adminService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/admin/service"
 	authHandler "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/auth/handler"
+	authService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/auth/service"
 	gmailsmtp "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/mailer/adapter/gmail-smtp"
+	resendAdapter "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/mailer/adapter/resend"
 	"github.com/GoEnterpricePlatform/goEP-core/pkg/identity/mailer/port"
 	mailerService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/mailer/service"
 	otpCodeRepository "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/opt-codes/repository/mongo"
@@ -31,8 +33,6 @@ import (
 	postHandler "github.com/GoEnterpricePlatform/goEP-core/web/admin/api/posts/handler"
 	adminRenderer "github.com/GoEnterpricePlatform/goEP-core/web/admin/renderer"
 	publicHandler "github.com/GoEnterpricePlatform/goEP-core/web/public/api/handler"
-	resendAdapter "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/mailer/adapter/resend"
-	authService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/auth/service"
 
 	cookieService "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/api/handler/cookie/service"
 
@@ -112,6 +112,10 @@ func New() http.Handler {
 
 	// Indexes
 	err = userRepo.CreateIndexes()
+	if err != nil {
+		log.Fatal(err)
+	}
+	err = postRepo.CreateIndexes()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/posts/handler/handler.go
+++ b/pkg/posts/handler/handler.go
@@ -20,6 +20,7 @@ func NewPostApiHandler(muxV1 *http.ServeMux, postSrv port.PostSrv) *Handler {
 	muxV1.HandleFunc("PUT /posts/{id}", h.Update)
 	muxV1.HandleFunc("PATCH /posts/{id}", h.Patch)
 	muxV1.HandleFunc("DELETE /posts/{id}", h.Delete)
+	muxV1.HandleFunc("GET /posts/search", h.Search)
 
 	return h
 }

--- a/pkg/posts/handler/search.go
+++ b/pkg/posts/handler/search.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	sharedC "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/api/core"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+// Search handles the HTTP request to search posts using a query string
+// and an optional limit parameter.
+func (h *Handler) Search(w http.ResponseWriter, r *http.Request) {
+	queryParams := r.URL.Query()
+
+	query := queryParams.Get("query")
+	limitStr := queryParams.Get("limit")
+
+	if query == "" {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "missing query parameter"))
+		return
+	}
+
+	limit := 10
+	if limitStr != "" {
+		if v, err := strconv.Atoi(limitStr); err == nil {
+			limit = v
+		}
+	}
+
+	posts, err := h.PostSrv.Search(r.Context(), query, limit)
+	if err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(posts)
+}

--- a/pkg/posts/port/ports.go
+++ b/pkg/posts/port/ports.go
@@ -12,6 +12,7 @@ type PostRepo interface {
 	FindAll(ctx context.Context) ([]*domain.Post, error)
 	Update(ctx context.Context, id string, post *domain.Post) error
 	Delete(ctx context.Context, id string) error
+	Search(ctx context.Context, query string, limit int) ([]*domain.Post, error)
 }
 
 type PostSrv interface {
@@ -20,4 +21,5 @@ type PostSrv interface {
 	Update(ctx context.Context, id string, post *domain.Post) error
 	Delete(ctx context.Context, id string) error
 	Patch(ctx context.Context, id string, post *domain.Post) (*domain.Post, error)
+	Search(ctx context.Context, query string, limit int) ([]*domain.Post, error)
 }

--- a/pkg/posts/repository/mongo/create_index.go
+++ b/pkg/posts/repository/mongo/create_index.go
@@ -1,0 +1,27 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func (r *Repository) CreateIndexes() error {
+	_, err := r.Collection.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys: bson.D{
+			{Key: "title", Value: "text"},
+			{Key: "desc", Value: "text"},
+		},
+		Options: options.Index().SetName("post_text_search").SetWeights(bson.D{
+			{Key: "title", Value: 10},
+			{Key: "desc", Value: 5},
+		}),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating post text index: %w", err)
+	}
+	return nil
+}

--- a/pkg/posts/repository/mongo/search.go
+++ b/pkg/posts/repository/mongo/search.go
@@ -1,0 +1,42 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/posts/domain"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/posts/model"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+func (r *Repository) Search(ctx context.Context, query string, limit int) ([]*domain.Post, error) {
+	filter := bson.M{
+		"$text": bson.M{
+			"$search": query,
+		},
+	}
+
+	opts := options.Find().SetLimit(int64(limit))
+
+	cursor, err := r.Collection.Find(ctx, filter, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error searching post: %w", err)
+	}
+	defer cursor.Close(ctx)
+
+	var posts []*domain.Post
+	for cursor.Next(ctx) {
+		var postModel model.PostNoSqlModel
+		err := cursor.Decode(&postModel)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding post: %w", err)
+		}
+		var post domain.Post
+		postModel.ToDomain(&post)
+
+		posts = append(posts, &post)
+	}
+
+	return posts, nil
+}

--- a/pkg/posts/service/search.go
+++ b/pkg/posts/service/search.go
@@ -1,0 +1,16 @@
+package service
+
+import (
+	"context"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/posts/domain"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func (s *Service) Search(ctx context.Context, query string, limit int) ([]*domain.Post, error) {
+	posts, err := s.PostRepo.Search(ctx, query, limit)
+	if err != nil {
+		return nil, sharedD.ManageError(err, "error searching posts")
+	}
+	return posts, nil
+}


### PR DESCRIPTION
### Tasks
- Introduced /posts/search endpoint
- Added service and repository search methods
- Created MongoDB text index on title and desc
- Enabled full-text search with weighted relevance

<img width="2154" height="1234" alt="image" src="https://github.com/user-attachments/assets/e8d80996-3818-4c87-bc9c-a6ba34a03f97" />

Close #36 