### PR TITLE
feat #47 (billing/payment-providers): add payment providers module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,12 @@ go.work.sum
 # Air live reload
 tmp/
 
-# docker data services, minio, mongo and others
-data/
+# docker data services, minio, mongo and others, 
+# It will use the dynamic folder appname_data
+# data/ 
+
+# Application runtime data
+*_data/
+
+# Keys
+*.key

--- a/cmd/api/server/v1/v1.go
+++ b/cmd/api/server/v1/v1.go
@@ -14,7 +14,10 @@ import (
 	resendClient "github.com/GoEnterpricePlatform/goEP-core/internal/resend"
 	openaiAdt "github.com/GoEnterpricePlatform/goEP-core/pkg/ai-tool-calling/adapter/open-ai"
 	aiTCItz "github.com/GoEnterpricePlatform/goEP-core/pkg/ai-tool-calling/initializer"
-	"github.com/GoEnterpricePlatform/goEP-core/pkg/ai-tool-calling/service"
+	toolCallingService "github.com/GoEnterpricePlatform/goEP-core/pkg/ai-tool-calling/service"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/handler"
+	pProviderRepo "github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/repository/mongo"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/service"
 	adminService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/admin/service"
 	authHandler "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/auth/handler"
 	authService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/auth/service"
@@ -38,11 +41,13 @@ import (
 	postHandlerWeb "github.com/GoEnterpricePlatform/goEP-core/web/admin/api/posts/handler"
 	adminRenderer "github.com/GoEnterpricePlatform/goEP-core/web/admin/renderer"
 	chatToolCallingHandler "github.com/GoEnterpricePlatform/goEP-core/web/ai-tool-calling/api/handler"
-	"github.com/GoEnterpricePlatform/goEP-core/web/ai-tool-calling/api/posts/handler"
+	toolCallingHandler "github.com/GoEnterpricePlatform/goEP-core/web/ai-tool-calling/api/posts/handler"
 	toolCallingRenderer "github.com/GoEnterpricePlatform/goEP-core/web/ai-tool-calling/renderer"
 	publicHandler "github.com/GoEnterpricePlatform/goEP-core/web/public/api/handler"
 
 	cookieService "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/api/handler/cookie/service"
+	encryptor "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/encryptor"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/shared/keystore"
 
 	sessionRepository "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/session/repository/mongo"
 	sessionService "github.com/GoEnterpricePlatform/goEP-core/pkg/identity/session/service"
@@ -113,6 +118,9 @@ func New() http.Handler {
 	permissionColl := mongoDB.Collection("permissions")
 	postColl := mongoDB.Collection("posts")
 
+	// collections - billing
+	pProviderColl := mongoDB.Collection("payment-providers")
+
 	// Repositories
 	userRepo := userRepository.NewUserRepo(mongoConn.DB, userColl)
 	sessionRepo := sessionRepository.NewSessionRepo(mongoConn.DB, sessionColl)
@@ -121,12 +129,21 @@ func New() http.Handler {
 	permissionRepo := permissionRepository.NewPermissionRepo(mongoConn.DB, permissionColl)
 	postRepo := postRepository.NewPostRepo(mongoConn.DB, postColl)
 
+	// Repositories - billing
+	pProviderRepo := pProviderRepo.NewPaymentProviderRepo(mongoConn.DB, pProviderColl)
+
 	// Indexes
 	err = userRepo.CreateIndexes()
 	if err != nil {
 		log.Fatal(err)
 	}
 	err = postRepo.CreateIndexes()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Indexes - billing
+	err = pProviderRepo.CreateIndexes()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -167,7 +184,18 @@ func New() http.Handler {
 	authSrv := authService.NewAuthSrv(userRepo, roleRepo, permissionRepo, userFileStg, sessionSrv, otpCodeSrv, mailerSrv)
 	userSrv := userService.NewUserSrv(userRepo, userFileStg)
 	postSrv := postService.NewPostSrv(postRepo)
-	toolCallingSrv := service.NewToolCallingSrv(toolCallingAdapter, aiTCInitializer, systemPrompt)
+	toolCallingSrv := toolCallingService.NewToolCallingSrv(toolCallingAdapter, aiTCInitializer, systemPrompt)
+
+	// Services - billing
+	keyStore := keystore.NewFileKeyStore(appEnvs.AppDataPath)
+
+	key, err := keyStore.LoadOrCreateKey()
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	encryptorSrv := encryptor.NewAESGCM(key)
+	pProviderSrv := service.NewPaymentProviderSrv(pProviderRepo, encryptorSrv)
 
 	// service - admin
 	adminSrv := adminService.NewAdminSrv(userRepo, roleRepo, permissionRepo, sessionSrv)
@@ -177,6 +205,9 @@ func New() http.Handler {
 	authHandler.NewAuthHandler(v1, authSrv, tokenSrv, appEnvs.AppEnv)
 	userHandler.NewUserHandler(v1, userSrv)
 	postHandler.NewPostApiHandler(v1, postSrv)
+
+	// Handler
+	handler.NewPaymentProviderApiHandler(v1, pProviderSrv)
 
 	// AI - Providers
 	postAIprovider := postAI.NewPostAiProvider(postSrv)
@@ -217,7 +248,7 @@ func New() http.Handler {
 
 	// tool Calling posts
 
-	toolCallingPostsH := handler.NewPostWebAiHandler(postSrv, appEnvs.ApiBaseUrl, toolCalllingR, mdwSrvTmpl)
+	toolCallingPostsH := toolCallingHandler.NewPostWebAiHandler(postSrv, appEnvs.ApiBaseUrl, toolCalllingR, mdwSrvTmpl)
 	toolCallingPostsH.RegisterRoutes(templateV1)
 
 	// Templates - post

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	AppEnv         string
 	AllowedOrigins []string
 	AppName        string // send email resend, gmail
+	AppDataPath    string
 
 	// Templates
 	ApiBaseUrl string
@@ -110,6 +111,8 @@ func Load(appStack *AppStack) *Config {
 	// "appname" appears in the email message
 	appName := mustGetEnv("APP_NAME")
 
+	appDataPath := appName + "_data"
+
 	// mailer
 	// Resend
 	var resendApiKey string
@@ -145,6 +148,7 @@ func Load(appStack *AppStack) *Config {
 		ResendApiKey:              resendApiKey,
 		ResendEmailFrom:           resendEmailFrom,
 		AppName:                   appName,
+		AppDataPath:               appDataPath,
 		GmailUsername:             gmailUsername,
 		GmailPass:                 gmailPass,
 		GmailFrom:                 gmailFrom,

--- a/pkg/billing/payment-providers/core/core.go
+++ b/pkg/billing/payment-providers/core/core.go
@@ -1,0 +1,25 @@
+package core
+
+import "github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+
+type CreateProviderReq struct {
+	ProviderName          domain.PProviderName   `json:"provider_name"`
+	StripeConfigReq       *StripeConfigReq       `json:"stripe,omitempty"`
+	LemonSqueezyConfigReq *LemonSqueezyConfigReq `json:"lemonsqueezy,omitempty"`
+}
+
+type LemonSqueezyConfigReq struct {
+	ApiKey        string `json:"api_key"`
+	StoreID       string `json:"store_id"`
+	WebhookSecret string `json:"webhook_secret"`
+}
+
+type StripeConfigReq struct {
+	PublishableKey string `json:"publishable_key"`
+	SecretKey      string `json:"secret_key"`
+	WebhookSecret  string `json:"webhook_secret"`
+}
+
+func (p *CreateProviderReq) Validate() error {
+	return validatePaymentProviderFields(p)
+}

--- a/pkg/billing/payment-providers/core/validate.go
+++ b/pkg/billing/payment-providers/core/validate.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"strings"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func validatePaymentProviderFields(provider *CreateProviderReq) error {
+	providerName := domain.PProviderName(
+		strings.TrimSpace(string(provider.ProviderName)),
+	)
+
+	if providerName == "" {
+		return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "provider_name is required")
+	}
+
+	switch providerName {
+	case domain.PProviderNameStripe:
+		if provider.StripeConfigReq == nil {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "stripe config is required")
+		}
+
+		if strings.TrimSpace(provider.StripeConfigReq.PublishableKey) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "stripe publishable_key is required")
+		}
+
+		if strings.TrimSpace(provider.StripeConfigReq.SecretKey) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "stripe secret_key is required")
+		}
+
+		if strings.TrimSpace(provider.StripeConfigReq.WebhookSecret) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "stripe webhook_secret is required")
+		}
+	case domain.PProviderNameLemonSqueezy:
+		if provider.LemonSqueezyConfigReq == nil {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "lemonsqueezy config is required")
+		}
+
+		if strings.TrimSpace(provider.LemonSqueezyConfigReq.ApiKey) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "lemonsqueezy api_key is required")
+		}
+
+		if strings.TrimSpace(provider.LemonSqueezyConfigReq.StoreID) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "lemonsqueezy store_id is required")
+		}
+
+		if strings.TrimSpace(provider.LemonSqueezyConfigReq.WebhookSecret) == "" {
+			return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "lemonsqueezy webhook_secret is required")
+		}
+	default:
+		return sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "provider_name is invalid")
+	}
+
+	return nil
+}

--- a/pkg/billing/payment-providers/domain/domain.go
+++ b/pkg/billing/payment-providers/domain/domain.go
@@ -1,0 +1,29 @@
+package domain
+
+import "time"
+
+type PaymentProvider struct {
+	ID                 string              `json:"id"`
+	Name               PProviderName       `json:"provider_name"`
+	Enabled            bool                `json:"enabled"`
+	StripeConfig       *StripeConfig       `json:"stripe,omitempty"`
+	LemonSqueezyConfig *LemonSqueezyConfig `json:"lemonsqueezy,omitempty"`
+	CreatedAt          *time.Time          `json:"created_at"`
+	UpdatedAt          *time.Time          `json:"updated_at"`
+}
+
+type StripeConfig struct {
+	PublishableKey         string `json:"publishable_key,omitempty"`
+	SecretKey              string `json:"-"`
+	SecretKeyEncrypted     string `json:"-"`
+	WebhookSecret          string `json:"-"`
+	WebhookSecretEncrypted string `json:"-"`
+}
+
+type LemonSqueezyConfig struct {
+	ApiKey                 string `json:"-"`
+	ApiKeyEncrypted        string `json:"-"`
+	StoreID                string `json:"store_id,omitempty"`
+	WebhookSecret          string `json:"-"`
+	WebhookSecretEncrypted string `json:"-"`
+}

--- a/pkg/billing/payment-providers/domain/types.go
+++ b/pkg/billing/payment-providers/domain/types.go
@@ -1,0 +1,8 @@
+package domain
+
+type PProviderName string
+
+const (
+	PProviderNameStripe       PProviderName = "stripe"
+	PProviderNameLemonSqueezy PProviderName = "lemonsqueezy"
+)

--- a/pkg/billing/payment-providers/handler/create.go
+++ b/pkg/billing/payment-providers/handler/create.go
@@ -1,0 +1,60 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/core"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+	sharedC "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/api/core"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func (h Handler) Create(w http.ResponseWriter, r *http.Request) {
+	var req core.CreateProviderReq
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		sharedC.RespondError(w, sharedD.NewAppError(sharedD.ErrCodeInvalidParams, "invalid request body"))
+		return
+	}
+
+	defer r.Body.Close()
+
+	if err := req.Validate(); err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	provider := &domain.PaymentProvider{
+		Name: req.ProviderName,
+	}
+
+	switch req.ProviderName {
+
+	case domain.PProviderNameStripe:
+
+		provider.StripeConfig = &domain.StripeConfig{
+			PublishableKey: req.StripeConfigReq.PublishableKey,
+			SecretKey:      req.StripeConfigReq.SecretKey,
+			WebhookSecret:  req.StripeConfigReq.WebhookSecret,
+		}
+
+	case domain.PProviderNameLemonSqueezy:
+
+		provider.LemonSqueezyConfig = &domain.LemonSqueezyConfig{
+			ApiKey:        req.LemonSqueezyConfigReq.ApiKey,
+			StoreID:       req.LemonSqueezyConfigReq.StoreID,
+			WebhookSecret: req.LemonSqueezyConfigReq.WebhookSecret,
+		}
+	}
+
+	if err := h.PProviderSrv.Create(context.Background(), provider); err != nil {
+		sharedC.RespondError(w, err)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(provider)
+}

--- a/pkg/billing/payment-providers/handler/handler.go
+++ b/pkg/billing/payment-providers/handler/handler.go
@@ -1,0 +1,21 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/port"
+)
+
+type Handler struct {
+	PProviderSrv port.PaymentProviderSrv
+}
+
+func NewPaymentProviderApiHandler(muxV1 *http.ServeMux, pProviderSrv port.PaymentProviderSrv) *Handler {
+	h := &Handler{
+		PProviderSrv: pProviderSrv,
+	}
+
+	muxV1.HandleFunc("POST /payments/provider", h.Create)
+
+	return h
+}

--- a/pkg/billing/payment-providers/model/model.go
+++ b/pkg/billing/payment-providers/model/model.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"time"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+type PaymentProviderNoSqlModel struct {
+	ID      bson.ObjectID        `bson:"_id"`
+	Name    domain.PProviderName `bson:"name"`
+	Enabled bool                 `bson:"enabled"`
+
+	StripeConfigModel       *StripeConfigModel       `bson:"stripe,omitempty"`
+	LemonSqueezyConfigModel *LemonSqueezyConfigModel `bson:"lemonsqueezy,omitempty"`
+
+	CreatedAt *time.Time `bson:"created_at,omitempty"`
+	UpdatedAt *time.Time `bson:"updated_at,omitempty"`
+}
+
+type StripeConfigModel struct {
+	PublishableKey         string `bson:"publishable_key"`
+	SecretKeyEncrypted     string `bson:"secret_key_encrypted"`
+	WebhookSecretEncrypted string `bson:"webhook_secret_encrypted"`
+}
+
+type LemonSqueezyConfigModel struct {
+	ApiKeyEncrypted        string `bson:"api_key_encrypted"`
+	StoreID                string `bson:"store_id"`
+	WebhookSecretEncrypted string `bson:"webhook_secret_encrypted"`
+}
+
+func (m *PaymentProviderNoSqlModel) ToDomain(p *domain.PaymentProvider) {
+	p.ID = m.ID.Hex()
+	p.Name = m.Name
+	p.Enabled = m.Enabled
+	p.CreatedAt = m.CreatedAt
+	p.UpdatedAt = m.UpdatedAt
+
+	if m.StripeConfigModel != nil {
+
+		p.StripeConfig = &domain.StripeConfig{
+			PublishableKey:         m.StripeConfigModel.PublishableKey,
+			SecretKeyEncrypted:     m.StripeConfigModel.SecretKeyEncrypted,
+			WebhookSecretEncrypted: m.StripeConfigModel.WebhookSecretEncrypted,
+		}
+	}
+
+	if m.LemonSqueezyConfigModel != nil {
+
+		p.LemonSqueezyConfig = &domain.LemonSqueezyConfig{
+			ApiKeyEncrypted:        m.LemonSqueezyConfigModel.ApiKeyEncrypted,
+			StoreID:                m.LemonSqueezyConfigModel.StoreID,
+			WebhookSecretEncrypted: m.LemonSqueezyConfigModel.WebhookSecretEncrypted,
+		}
+	}
+}
+
+func FromDomain(p *domain.PaymentProvider,id bson.ObjectID) *PaymentProviderNoSqlModel {
+	if p == nil {
+		return nil
+	}
+
+	model := &PaymentProviderNoSqlModel{
+		ID:        id,
+		Name:      p.Name,
+		Enabled:   p.Enabled,
+		CreatedAt: p.CreatedAt,
+		UpdatedAt: p.UpdatedAt,
+	}
+
+	if p.StripeConfig != nil {
+		model.StripeConfigModel = &StripeConfigModel{
+			PublishableKey:         p.StripeConfig.PublishableKey,
+			SecretKeyEncrypted:     p.StripeConfig.SecretKeyEncrypted,
+			WebhookSecretEncrypted: p.StripeConfig.WebhookSecretEncrypted,
+		}
+	}
+
+	if p.LemonSqueezyConfig != nil {
+		model.LemonSqueezyConfigModel = &LemonSqueezyConfigModel{
+			ApiKeyEncrypted:        p.LemonSqueezyConfig.ApiKeyEncrypted,
+			StoreID:                p.LemonSqueezyConfig.StoreID,
+			WebhookSecretEncrypted: p.LemonSqueezyConfig.WebhookSecretEncrypted,
+		}
+	}
+
+	return model
+}

--- a/pkg/billing/payment-providers/port/ports.go
+++ b/pkg/billing/payment-providers/port/ports.go
@@ -1,0 +1,15 @@
+package port
+
+import (
+	"context"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+)
+
+type PaymentProviderSrv interface {
+	Create(ctx context.Context, pProvider *domain.PaymentProvider) error
+}
+
+type PaymentProviderRepo interface {
+	Insert(ctx context.Context, pProvider *domain.PaymentProvider) error
+}

--- a/pkg/billing/payment-providers/repository/mongo/create_index.go
+++ b/pkg/billing/payment-providers/repository/mongo/create_index.go
@@ -1,0 +1,22 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+)
+
+// * CreateIndexes sets a unique index on the "name" field.
+func (r *Repository) CreateIndexes() error {
+	_, err := r.Collection.Indexes().CreateOne(context.Background(), mongo.IndexModel{
+		Keys:    bson.D{{Key: "name", Value: 1}},
+		Options: options.Index().SetUnique(true).SetName("unique_payment_provider_name"),
+	})
+	if err != nil {
+		return fmt.Errorf("error creating payment provider name index: %w", err)
+	}
+	return nil
+}

--- a/pkg/billing/payment-providers/repository/mongo/insert.go
+++ b/pkg/billing/payment-providers/repository/mongo/insert.go
@@ -1,0 +1,31 @@
+package mongo
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/model"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+)
+
+func (r *Repository) Insert(ctx context.Context, pProvider *domain.PaymentProvider) error {
+	id := bson.NewObjectID()
+
+	providerModel := model.FromDomain(pProvider, id)
+
+	_, err := r.Collection.InsertOne(ctx, providerModel)
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: error inserting payment provider: %s", sharedD.ErrDuplicateKey, err.Error())
+		}
+		return fmt.Errorf("error inserting payment provider: %s", err.Error())
+	}
+
+	providerModel.ToDomain(pProvider)
+
+	return nil
+}

--- a/pkg/billing/payment-providers/repository/mongo/repository.go
+++ b/pkg/billing/payment-providers/repository/mongo/repository.go
@@ -1,0 +1,20 @@
+package mongo
+
+import (
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/port"
+)
+
+var _ port.PaymentProviderRepo = &Repository{}
+
+type Repository struct {
+	Client     *mongo.Client
+	Collection *mongo.Collection
+}
+
+func NewPaymentProviderRepo(client *mongo.Client, collection *mongo.Collection) *Repository {
+	return &Repository{
+		Client:     client,
+		Collection: collection,
+	}
+}

--- a/pkg/billing/payment-providers/service/create.go
+++ b/pkg/billing/payment-providers/service/create.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+	"time"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/domain"
+	sharedD "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func (s *Service) Create(ctx context.Context, pProvider *domain.PaymentProvider) error {
+	now := time.Now().UTC()
+	pProvider.CreatedAt = &now
+	pProvider.UpdatedAt = &now
+	pProvider.Enabled = false
+
+	switch pProvider.Name {
+	case domain.PProviderNameStripe:
+		err := validateStripeCredentials(pProvider.StripeConfig.SecretKey)
+		if err != nil {
+			return sharedD.ManageError(err,"stripe validation failed")
+		}
+
+		secretKey, err := s.EncryptorSrv.Encrypt(pProvider.StripeConfig.SecretKey)
+		if err != nil {
+			return sharedD.ManageError(err, "error encrypting secret_key")
+		}
+
+		webhookSecret, err := s.EncryptorSrv.Encrypt(pProvider.StripeConfig.WebhookSecret)
+		if err != nil {
+			return sharedD.ManageError(err, "error encrypting webhook_secret")
+		}
+
+		pProvider.StripeConfig.SecretKeyEncrypted = secretKey
+		pProvider.StripeConfig.WebhookSecretEncrypted = webhookSecret
+
+		pProvider.StripeConfig.SecretKey = ""
+		pProvider.StripeConfig.WebhookSecret = ""
+
+	case domain.PProviderNameLemonSqueezy:
+		err := validateLemonSqueezyCredentials(pProvider.LemonSqueezyConfig.ApiKey)
+		if err != nil {
+			return sharedD.ManageError(err,"lemonsqueezy validation failed")
+		}
+
+		apiKey, err := s.EncryptorSrv.Encrypt(pProvider.LemonSqueezyConfig.ApiKey)
+		if err != nil {
+			return sharedD.ManageError(err, "error encrypting api_key")
+		}
+
+		webhookSecret, err := s.EncryptorSrv.Encrypt(pProvider.LemonSqueezyConfig.WebhookSecret)
+		if err != nil {
+			return sharedD.ManageError(err, "error encrypting webhook_secret")
+		}
+
+		pProvider.LemonSqueezyConfig.ApiKeyEncrypted = apiKey
+		pProvider.LemonSqueezyConfig.WebhookSecretEncrypted = webhookSecret
+
+		pProvider.LemonSqueezyConfig.ApiKey = ""
+		pProvider.LemonSqueezyConfig.WebhookSecret = ""
+	}
+
+	err := s.PProviderRepo.Insert(ctx, pProvider)
+	if err != nil {
+		return sharedD.ManageError(err, "")
+	}
+
+	return nil
+}

--- a/pkg/billing/payment-providers/service/lemonsqueezy.go
+++ b/pkg/billing/payment-providers/service/lemonsqueezy.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func validateLemonSqueezyCredentials(apiKey string) error {
+	req, err := http.NewRequest(
+		http.MethodGet,
+		"https://api.lemonsqueezy.com/v1/stores",
+		nil,
+	)
+	if err != nil {
+		return fmt.Errorf("creating lemonsqueezy request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/vnd.api+json")
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling lemonsqueezy api: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		_, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to read lemonsqueezy error response: %v", err)
+		}
+		return fmt.Errorf("%w", domain.ErrInvalidLemonSqueezyCredentials)
+	}
+
+	return nil
+}

--- a/pkg/billing/payment-providers/service/service.go
+++ b/pkg/billing/payment-providers/service/service.go
@@ -1,0 +1,20 @@
+package service
+
+import (
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/billing/payment-providers/port"
+	encryptor "github.com/GoEnterpricePlatform/goEP-core/pkg/shared/encryptor"
+)
+
+var _ port.PaymentProviderSrv = &Service{}
+
+type Service struct {
+	PProviderRepo port.PaymentProviderRepo
+	EncryptorSrv encryptor.EncryptorSrv
+}
+
+func NewPaymentProviderSrv(pProviderRepo port.PaymentProviderRepo, encryptorSrv encryptor.EncryptorSrv) *Service {
+	return &Service{
+		PProviderRepo: pProviderRepo,
+		EncryptorSrv: encryptorSrv,
+	}
+}

--- a/pkg/billing/payment-providers/service/stripe_validate.go
+++ b/pkg/billing/payment-providers/service/stripe_validate.go
@@ -1,0 +1,39 @@
+package service
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/GoEnterpricePlatform/goEP-core/pkg/shared/domain"
+)
+
+func validateStripeCredentials(secretKey string) error {
+	req, err := http.NewRequest(http.MethodGet, "https://api.stripe.com/v1/balance", nil)
+	if err != nil {
+		return fmt.Errorf("creating stripe request: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+secretKey)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("calling stripe api: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("unable to read stripe error response: %v",err)
+		}
+		return fmt.Errorf("%w: %s", domain.ErrInvalidStripeCredentials, string(body))
+	}
+
+	return nil
+}

--- a/pkg/shared/domain/app_error.go
+++ b/pkg/shared/domain/app_error.go
@@ -139,6 +139,19 @@ func ManageError(err error, msg string) error {
 			Code: ErrCodeUnauthorized,
 			Msg:  "Invalid api key",
 		}
+	case errors.Is(err, ErrInvalidStripeCredentials):
+		log.Println("Invalid stripe credentials")
+		appErr = AppError{
+			Code: ErrCodeInvalidParams,
+			Msg:  "Invalid stripe credentials",
+		}
+
+	case errors.Is(err, ErrInvalidLemonSqueezyCredentials):
+		log.Println("Invalid lemonSqueezy credentials")
+		appErr = AppError{
+			Code: ErrCodeInvalidParams,
+			Msg:  "Invalid lemonSqueezy credentials",
+		}
 
 	default:
 		log.Println(err.Error())

--- a/pkg/shared/domain/errors.go
+++ b/pkg/shared/domain/errors.go
@@ -46,3 +46,9 @@ var (
 var (
 	ErrInvalidApiKey = errors.New("invalid api key")
 )
+
+// Billing
+var (
+	ErrInvalidStripeCredentials       = errors.New("invalid stripe credentials")
+	ErrInvalidLemonSqueezyCredentials = errors.New("invalid lemonsqueezy credentials")
+)

--- a/pkg/shared/encryptor/aesgcm.go
+++ b/pkg/shared/encryptor/aesgcm.go
@@ -1,0 +1,90 @@
+package encryptor
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"io"
+)
+
+type AESGCM struct {
+	key []byte
+}
+
+func NewAESGCM(key []byte) *AESGCM {
+	return &AESGCM{
+		key: key,
+	}
+}
+
+func (a *AESGCM) Encrypt(value string) (string, error) {
+
+	block, err := aes.NewCipher(a.key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return "", err
+	}
+
+	encrypted := gcm.Seal(
+		nonce,
+		nonce,
+		[]byte(value),
+		nil,
+	)
+
+	return base64.StdEncoding.EncodeToString(
+		encrypted,
+	), nil
+}
+
+func (a *AESGCM) Decrypt(value string) (string, error) {
+
+	data, err := base64.StdEncoding.DecodeString(value)
+	if err != nil {
+		return "", err
+	}
+
+	block, err := aes.NewCipher(a.key)
+	if err != nil {
+		return "", err
+	}
+
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	nonceSize := gcm.NonceSize()
+
+	if len(data) < nonceSize {
+		return "", io.ErrUnexpectedEOF
+	}
+
+	nonce := data[:nonceSize]
+
+	cipherText := data[nonceSize:]
+
+	plain, err := gcm.Open(
+		nil,
+		nonce,
+		cipherText,
+		nil,
+	)
+	if err != nil {
+		return "", err
+	}
+
+	return string(plain), nil
+}

--- a/pkg/shared/encryptor/encryptor.go
+++ b/pkg/shared/encryptor/encryptor.go
@@ -1,0 +1,6 @@
+package encryptor
+
+type EncryptorSrv interface {
+	Encrypt(value string) (string, error)
+	Decrypt(value string) (string, error)
+}

--- a/pkg/shared/keystore/create.go
+++ b/pkg/shared/keystore/create.go
@@ -1,0 +1,44 @@
+package keystore
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"os"
+	"path/filepath"
+)
+
+func (k *FileKeyStore) CreateKey() ([]byte, error) {
+
+	keyPath := filepath.Join(
+		k.appDataPath,
+		keyDir,
+		keyFile,
+	)
+
+	dir := filepath.Dir(keyPath)
+
+	err := os.MkdirAll(dir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	key := make([]byte, keySize)
+
+	_, err = rand.Read(key)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded := base64.StdEncoding.EncodeToString(key)
+
+	err = os.WriteFile(
+		keyPath,
+		[]byte(encoded),
+		0600,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}

--- a/pkg/shared/keystore/file_keystore.go
+++ b/pkg/shared/keystore/file_keystore.go
@@ -1,0 +1,36 @@
+package keystore
+
+import (
+	"errors"
+	"os"
+)
+
+const (
+	keySize = 32
+	keyDir  = "keys"
+	keyFile = "payment-encryption.key"
+)
+
+type FileKeyStore struct {
+	appDataPath string
+}
+
+func NewFileKeyStore(appDataPath string) *FileKeyStore {
+	return &FileKeyStore{
+		appDataPath: appDataPath,
+	}
+}
+
+func (k *FileKeyStore) LoadOrCreateKey() ([]byte, error) {
+
+	key, err := k.GetKey()
+	if err == nil {
+		return key, nil
+	}
+
+	if errors.Is(err, os.ErrNotExist) {
+		return k.CreateKey()
+	}
+
+	return nil, err
+}

--- a/pkg/shared/keystore/get_key.go
+++ b/pkg/shared/keystore/get_key.go
@@ -1,0 +1,26 @@
+package keystore
+
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func (k *FileKeyStore) GetKey() ([]byte, error) {
+
+	keyPath := filepath.Join(
+		k.appDataPath,
+		keyDir,
+		keyFile,
+	)
+
+	data, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	return base64.StdEncoding.DecodeString(
+		strings.TrimSpace(string(data)),
+	)
+}

--- a/pkg/shared/keystore/keystore.go
+++ b/pkg/shared/keystore/keystore.go
@@ -1,0 +1,7 @@
+package keystore
+
+type KeyStore interface {
+	GetKey() ([]byte, error)
+	CreateKey() ([]byte, error)
+	LoadOrCreateKey() ([]byte, error)
+}


### PR DESCRIPTION
# Tasks
- create payment-providers module
- add Stripe and LemonSqueezy provider support
- implement request validation
- register payment provider HTTP endpoints
- add MongoDB repository and indexes
- integrate module into application startup
Close #47 