### PR TITLE
feat #58: add Bruno API collection with v1 endpoints

### DIFF
--- a/docs/api-docs/bruno/bruno.json
+++ b/docs/api-docs/bruno/bruno.json
@@ -1,0 +1,5 @@
+{
+  "version": "1",
+  "name": "goep-core",
+  "type": "collection"
+}

--- a/docs/api-docs/bruno/collection.bru
+++ b/docs/api-docs/bruno/collection.bru
@@ -1,0 +1,3 @@
+headers {
+  Authorization: Bearer {{access_token}}
+}

--- a/docs/api-docs/bruno/environments/development-dev.bru
+++ b/docs/api-docs/bruno/environments/development-dev.bru
@@ -1,0 +1,12 @@
+vars {
+  baseUrl: http://localhost:8000
+  environment: development
+  timeout: 30000
+  retryAttempts: 3
+}
+vars:secret [
+  stripe_publishable_key,
+  stripe_secret_key,
+  stripe_webhook_secret,
+  access_token
+]

--- a/docs/api-docs/bruno/environments/prod-main.bru
+++ b/docs/api-docs/bruno/environments/prod-main.bru
@@ -1,0 +1,6 @@
+vars {
+  baseUrl: ""
+  environment: production
+  timeout: 20000
+  retryAttempts: 1
+}

--- a/docs/api-docs/bruno/v1/billing/folder.bru
+++ b/docs/api-docs/bruno/v1/billing/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: billing
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/billing/payment-providers/Create.bru
+++ b/docs/api-docs/bruno/v1/billing/payment-providers/Create.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Create
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/payments/provider
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "provider_name": "stripe",
+      "stripe": {
+          "publishable_key": "{{stripe_publishable_key}}",
+          "secret_key": "{{stripe_secret_key}}",
+          "webhook_secret": "{{stripe_webhook_secret}}"
+      }
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/billing/payment-providers/folder.bru
+++ b/docs/api-docs/bruno/v1/billing/payment-providers/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: payment-providers
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/catalog/folder.bru
+++ b/docs/api-docs/bruno/v1/catalog/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: catalog
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/catalog/var-options/Create.bru
+++ b/docs/api-docs/bruno/v1/catalog/var-options/Create.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Create
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/variations/6a7271baf20ec766c0e68057/options
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "label": "anual"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/var-options/Delete.bru
+++ b/docs/api-docs/bruno/v1/catalog/var-options/Delete.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Delete
+  type: http
+  seq: 3
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/variations/6a7271baf20ec766c0e68057/options/6a81ddb3bd3dc3fbdd759b26
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/var-options/Update.bru
+++ b/docs/api-docs/bruno/v1/catalog/var-options/Update.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Update
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/v1/variations/6a7271baf20ec766c0e68057/options/6a81ddb3bd3dc3fbdd759b26
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "label":"var-option updated"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/var-options/folder.bru
+++ b/docs/api-docs/bruno/v1/catalog/var-options/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: var-options
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/catalog/variations/Create.bru
+++ b/docs/api-docs/bruno/v1/catalog/variations/Create.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Create
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/variations
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name":"basic plan"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/variations/Delete.bru
+++ b/docs/api-docs/bruno/v1/catalog/variations/Delete.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Delete
+  type: http
+  seq: 4
+}
+
+delete {
+  url: {{baseUrl}}/api/v1/variations/6a81dc39bd3dc3fbdd759b25
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/variations/Get all with options.bru
+++ b/docs/api-docs/bruno/v1/catalog/variations/Get all with options.bru
@@ -1,0 +1,15 @@
+meta {
+  name: Get all with options
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{baseUrl}}/api/v1/variations/options
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+}

--- a/docs/api-docs/bruno/v1/catalog/variations/Update.bru
+++ b/docs/api-docs/bruno/v1/catalog/variations/Update.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Update
+  type: http
+  seq: 2
+}
+
+put {
+  url: {{baseUrl}}/api/v1/variations/6a810dcca1716cd809139889
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "name":"basic plan updated"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/catalog/variations/folder.bru
+++ b/docs/api-docs/bruno/v1/catalog/variations/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: variations
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/folder.bru
+++ b/docs/api-docs/bruno/v1/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: v1
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Get session.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Get session.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Get session
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{baseUrl}}/api/v1/auth/get-session
+  body: none
+  auth: inherit
+}
+
+script:post-response {
+  // Parse the response body
+  const response = res.getBody();
+  const jsonResponse = response;
+  
+  // Save the access token to environment variables (SECRET - stored in vars:secret)
+  bru.setEnvVar('access_token', jsonResponse.session.access_token);
+  
+  // Optional: Save other user data (these can be in vars if not sensitive)
+  // bru.setEnvVar('user_id', jsonResponse.user.id);
+  // bru.setEnvVar('user_email', jsonResponse.user.email);
+  
+  // Optional: Save token expiration time if available
+  // bru.setEnvVar('token_expires_at', jsonResponse.session.expires_at);
+  
+  // Optional: Log success (only for debugging)
+  // console.log('Access token saved successfully');
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Refresh token.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Refresh token.bru
@@ -1,0 +1,35 @@
+meta {
+  name: Refresh token
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/refresh-token
+  body: none
+  auth: inherit
+}
+
+script:post-response {
+  // Parse the response body
+  const response = res.getBody();
+  const jsonResponse = response;
+  
+  // Save the access token to environment variables (SECRET - stored in vars:secret)
+  bru.setEnvVar('access_token', jsonResponse.session.access_token);
+  
+  // Optional: Save other user data (these can be in vars if not sensitive)
+  // bru.setEnvVar('user_id', jsonResponse.user.id);
+  // bru.setEnvVar('user_email', jsonResponse.user.email);
+  
+  // Optional: Save token expiration time if available
+  // bru.setEnvVar('token_expires_at', jsonResponse.session.expires_at);
+  
+  // Optional: Log success (only for debugging)
+  // console.log('Access token saved successfully');
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Resend verify email.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Resend verify email.bru
@@ -1,0 +1,22 @@
+meta {
+  name: Resend verify email
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/resend-verify-email
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email":"fernan@yopmail.com"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Sign in.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Sign in.bru
@@ -1,0 +1,42 @@
+meta {
+  name: Sign in
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/sign-in
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email":"user@yopmail.com",
+    "password":"123456()Pass"
+  }
+}
+
+script:post-response {
+  // Parse the response body
+  const response = res.getBody();
+  const jsonResponse = response;
+  
+  // Save the access token to environment variables (SECRET - stored in vars:secret)
+  bru.setEnvVar('access_token', jsonResponse.session.access_token);
+  
+  // Optional: Save other user data (these can be in vars if not sensitive)
+  // bru.setEnvVar('user_id', jsonResponse.user.id);
+  // bru.setEnvVar('user_email', jsonResponse.user.email);
+  
+  // Optional: Save token expiration time if available
+  // bru.setEnvVar('token_expires_at', jsonResponse.session.expires_at);
+  
+  // Optional: Log success (only for debugging)
+  // console.log('Access token saved successfully');
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Sign out.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Sign out.bru
@@ -1,0 +1,30 @@
+meta {
+  name: Sign out
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/sign-out
+  body: none
+  auth: inherit
+}
+
+script:post-response {
+  // Set access token to null
+  bru.setEnvVar('access_token', null);
+  
+  
+  
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}
+
+docs {
+  Docs
+  
+  At the bottom right, this cookie, when signing out, Bruno doesn't visually delete the refreshToken cookie, but it can still be used, and when making any other request that needs the refreshToken cookie, it shows the correct error: "refresh token cookie not found".
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Sign up.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Sign up.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Sign up
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/sign-up
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "email":"fernan@yopmail.com",
+    "password":"123456()Pass",
+    "confirm_password":"123456()Pass"
+  }
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/Verify email.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/Verify email.bru
@@ -1,0 +1,43 @@
+meta {
+  name: Verify email
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{baseUrl}}/api/v1/auth/verify-email
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "otp_id":"6a8240173ad31360f7f6b083",
+    "otp_code": "703816",
+    "user_id": "6a823ec03ad31360f7f6b07f"
+  }
+}
+
+script:post-response {
+  // Parse the response body
+  const response = res.getBody();
+  const jsonResponse = response;
+  
+  // Save the access token to environment variables (SECRET - stored in vars:secret)
+  bru.setEnvVar('access_token', jsonResponse.session.access_token);
+  
+  // Optional: Save other user data (these can be in vars if not sensitive)
+  // bru.setEnvVar('user_id', jsonResponse.user.id);
+  // bru.setEnvVar('user_email', jsonResponse.user.email);
+  
+  // Optional: Save token expiration time if available
+  // bru.setEnvVar('token_expires_at', jsonResponse.session.expires_at);
+  
+  // Optional: Log success (only for debugging)
+  // console.log('Access token saved successfully');
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/auth/folder.bru
+++ b/docs/api-docs/bruno/v1/identity/auth/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: auth
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/identity/folder.bru
+++ b/docs/api-docs/bruno/v1/identity/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: identity
+  seq: 3
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/identity/users/Upload avatar.bru
+++ b/docs/api-docs/bruno/v1/identity/users/Upload avatar.bru
@@ -1,0 +1,24 @@
+meta {
+  name: Upload avatar
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{baseUrl}}/api/v1/users/6a80876985553cb9390485d9/avatar
+  body: multipartForm
+  auth: inherit
+}
+
+body:multipart-form {
+  image: @file(C:\Users\ferna\OneDrive\Documentos\p\foto\avatar.png) @contentType(image/png)
+}
+
+body:file {
+  file: @file(C:\Users\ferna\OneDrive\Documentos\dev\Gopher_.png) @contentType(image/png)
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/identity/users/folder.bru
+++ b/docs/api-docs/bruno/v1/identity/users/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: users
+  seq: 2
+}
+
+auth {
+  mode: inherit
+}

--- a/docs/api-docs/bruno/v1/shared/Ping.bru
+++ b/docs/api-docs/bruno/v1/shared/Ping.bru
@@ -1,0 +1,16 @@
+meta {
+  name: Ping
+  type: http
+  seq: 1
+}
+
+get {
+  url: {{baseUrl}}/ping
+  body: none
+  auth: inherit
+}
+
+settings {
+  encodeUrl: true
+  timeout: 0
+}

--- a/docs/api-docs/bruno/v1/shared/folder.bru
+++ b/docs/api-docs/bruno/v1/shared/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: shared
+  seq: 4
+}
+
+auth {
+  mode: inherit
+}


### PR DESCRIPTION
Add complete Bruno collection including:
- Environments: development-dev and prod-main
- Endpoints for billing, catalog, identity, and shared modules
- All CRUD operations and authentication flows

<img width="494" height="888" alt="image" src="https://github.com/user-attachments/assets/21778b93-ad85-4c87-b020-8c3ba526000e" />
<img width="2380" height="1503" alt="image" src="https://github.com/user-attachments/assets/7286420c-6049-4259-a77e-917025e4e002" />

Close #58 