### PR TITLE
feat #94 (billing): add Paddle MoR as optional payment provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,12 @@ GMAIL_PASS=
 # LLM_PROVIDER=openai
 # OPENAI_API_KEY=
 
+# Merchant of Record (MoR)
+
+## Paddle
+# IS_ENABLE_MOR_PADDLE=true
+# PADDLE_API_KEY=
+
 # HTTP_SERVER_PORT=8001
 
 # * Only for development — variables for docker-compose.dev and development tools

--- a/docs/documentation/payments/payments.md
+++ b/docs/documentation/payments/payments.md
@@ -1,0 +1,22 @@
+# Payments
+
+There are ways to receive payments, through payment processors and MoR.
+
+## Payment processor (Stripe)
+Its main function is to move money from the client's account to yours. However, this makes you the **Seller of Record**, which means that you are legally responsible for calculating, collecting and reporting taxes (VAT/Sales Tax), issuing legal invoices and managing the tax file.
+
+## Merchant of Record (MoR)
+It is an entity that assumes complete fiscal responsibility. The MoR becomes the legal Seller of Record before the authorities. This frees you from the administrative burden of calculating international taxes, issuing invoices and managing returns or chargebacks.
+
+## Feature comparison
+
+| Feature | Payment Processor (e.g. Stripe) | Merchant of Record (e.g. Polar, Paddle) |
+|---|---|---|
+| Fiscal responsibility | The owner of the SaaS (Seller of Record) | The MoR takes responsibility |
+| Tax management | Manual or with external tools (Stripe Tax) | Automatic and managed by the MoR |
+| Legal billing | User Responsibility | MoR issues legal invoices |
+| Commissions | Minor (~2.9% + 0.30) | Seniors (4% - 8%) |
+| Chargebacks | User risk and management | The MoR usually manages them |
+
+MoR has higher commissions, the cost is justified by delegating the "fiscal plumbing" and avoiding legal risks.
+As an independent developer I will be working with MoR.

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,8 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.59.0 // indirect
 	github.com/Ladicle/tabwriter v1.0.0 // indirect
 	github.com/Masterminds/semver/v3 v3.5.0 // indirect
+	github.com/PaddleHQ/paddle-go-sdk v1.0.0 // indirect
+	github.com/PaddleHQ/paddle-go-sdk/v5 v5.2.0 // indirect
 	github.com/a-h/parse v0.0.0-20250122154542-74294addb73e // indirect
 	github.com/air-verse/air v1.67.1 // indirect
 	github.com/alecthomas/chroma/v2 v2.27.0 // indirect
@@ -90,6 +92,8 @@ require (
 	github.com/felixge/httpsnoop v1.1.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
+	github.com/ggicci/httpin v0.20.3 // indirect
+	github.com/ggicci/owl v0.8.2 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-logr/logr v1.4.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,10 @@ github.com/Ladicle/tabwriter v1.0.0 h1:DZQqPvMumBDwVNElso13afjYLNp0Z7pHqHnu0r4t9
 github.com/Ladicle/tabwriter v1.0.0/go.mod h1:c4MdCjxQyTbGuQO/gvqJ+IA/89UEwrsD6hUCW98dyp4=
 github.com/Masterminds/semver/v3 v3.5.0 h1:kQceYJfbupGfZOKZQg0kou0DgAKhzDg2NZPAwZ/2OOE=
 github.com/Masterminds/semver/v3 v3.5.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
+github.com/PaddleHQ/paddle-go-sdk v1.0.0 h1:+EXitsPFbRcc0CpQE/MIeudxiVOR8pFe/aOWTEUHDKU=
+github.com/PaddleHQ/paddle-go-sdk v1.0.0/go.mod h1:kbBBzf0BHEj38QvhtoELqlGip3alKgA/I+vl7RQzB58=
+github.com/PaddleHQ/paddle-go-sdk/v5 v5.2.0 h1:HJabVGWEsDyogj1Ib/ZGcMcP9Vc/e2tqIDYx0xZA+qI=
+github.com/PaddleHQ/paddle-go-sdk/v5 v5.2.0/go.mod h1:nlFfZYf7MovyHTE67+u7BARbMiBdMMLXGuQMbCVm9ss=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e h1:HjVbSQHy+dnlS6C3XajZ69NYAb5jbGNfHanvm1+iYlo=
 github.com/a-h/parse v0.0.0-20250122154542-74294addb73e/go.mod h1:3mnrkvGpurZ4ZrTDbYU84xhwXW2TjTKShSwjRi2ihfQ=
 github.com/a-h/templ v0.3.1020 h1:ypAT/L5ySWEnZ6Zft/5yfoWXYYkhFNvEFOeeqecg4tw=
@@ -208,6 +212,12 @@ github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3G
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/getkin/kin-openapi v0.139.0 h1:pBFXcZJFwz9J1X64jzxlOoNgFm+TF7kNrs9+HJVN6Ic=
 github.com/getkin/kin-openapi v0.139.0/go.mod h1:NGxPfE4PwS/TRXEbyx2RrxDFPZvxcWw31Tw8XXjPZLs=
+github.com/ggicci/httpin v0.19.0 h1:p0B3SWLVgg770VirYiHB14M5wdRx3zR8mCTzM/TkTQ8=
+github.com/ggicci/httpin v0.19.0/go.mod h1:hzsQHcbqLabmGOycf7WNw6AAzcVbsMeoOp46bWAbIWc=
+github.com/ggicci/httpin v0.20.3 h1:qy93bUsF/eGbX8WJfXEjB3bjgUrv7MKZ3qVWR73DIGY=
+github.com/ggicci/httpin v0.20.3/go.mod h1:ppHGT8xt99mRnDUuehLLWl2RAVLKG+VGn48GjK5xaLA=
+github.com/ggicci/owl v0.8.2 h1:og+lhqpzSMPDdEB+NJfzoAJARP7qCG3f8uUC3xvGukA=
+github.com/ggicci/owl v0.8.2/go.mod h1:PHRD57u41vFN5UtFz2SF79yTVoM3HlWpjMiE+ZU2dj4=
 github.com/go-ini/ini v1.67.0 h1:z6ZrTEZqSWOTyH2FlglNbNgARyHG8oLW9gMELqKr06A=
 github.com/go-ini/ini v1.67.0/go.mod h1:ByCAeIL28uOIIG0E3PJtZPDL8WnHpFKFOtgjp+3Ies8=
 github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=

--- a/internal/config/app_clients.go
+++ b/internal/config/app_clients.go
@@ -7,6 +7,7 @@ import (
 	minioClient "github.com/GoEnterpricePlatform/goEP-core/internal/minio"
 	mongoClient "github.com/GoEnterpricePlatform/goEP-core/internal/mongo"
 	openai "github.com/GoEnterpricePlatform/goEP-core/internal/open-ai"
+	paddleClient "github.com/GoEnterpricePlatform/goEP-core/internal/paddle"
 	resendClient "github.com/GoEnterpricePlatform/goEP-core/internal/resend"
 
 	"github.com/resend/resend-go/v2"
@@ -27,6 +28,9 @@ type AppClients struct {
 
 	// Optionals services
 	OpenaiCli *openai.OpenaiClient
+
+	// optional paddle
+	PaddleCli *paddleClient.PaddleClient
 }
 
 func NewClients() *AppClients {
@@ -55,12 +59,18 @@ func (ac *AppClients) GetClients(appEnvs *AppEnvs) error {
 		ac.MinioCli = minioCli
 	}
 
-
 	switch appEnvs.LLMProvider {
 	case LLMOpenAI:
 		ac.OpenaiCli = openai.NewOpenAIClient(appEnvs.OpenAiApiKey)
 	}
 
+	if appEnvs.IsEnableMorPaddle {
+		paddleCli, err := paddleClient.NewPaddleClient(appEnvs.PaddleApiKey)
+		if err != nil {
+			return err
+		}
+		ac.PaddleCli = paddleCli
+	}
 	return nil
 }
 

--- a/internal/config/app_envs.go
+++ b/internal/config/app_envs.go
@@ -41,6 +41,10 @@ type AppEnvs struct {
 	// OpenAI
 	OpenAiApiKey string
 
+	// payments MoR
+	IsEnableMorPaddle bool
+	PaddleApiKey string
+
 	// Jwt
 	JWTAccessSecret           string
 	JWTRefreshSecret          string

--- a/internal/config/app_envs_load.go
+++ b/internal/config/app_envs_load.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"log"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -61,6 +62,19 @@ func (ae *AppEnvs) Load() {
 		log.Fatalf("invalid FILE_STORAGE_PROVIDER: %q", fileStorageProviderValue)
 	}
 
+	// We don't know if one or the other MoR or both will be used, so I will validate it separately and not switch
+	isEnableMorPaddle, err := strconv.ParseBool(cmp.Or(os.Getenv("IS_ENABLE_MOR_PADDLE"), "false"))
+	if err != nil {
+		log.Fatal("IS_ENABLE_MOR_PADDLE must be a boolean")
+	}
+
+	// paddle
+	var paddleApiKey string
+
+	if isEnableMorPaddle {
+		paddleApiKey = mustGetEnv("PADDLE_API_KEY")
+	}
+
 	// Auth - tokens
 	accessExp := cmp.Or(os.Getenv("JWT_ACCESS_EXP_IN"), "15m")
 	refreshExp := cmp.Or(os.Getenv("JWT_REFRESH_EXP_IN"), "168h")
@@ -98,7 +112,6 @@ func (ae *AppEnvs) Load() {
 	default:
 		log.Fatalf("invalid LLM_PROVIDER: %q", llmProviderValue)
 	}
-
 
 	// Cookies
 	// JWT_ACCESS_COOKIE_EXP_IN defines how long the access token cookie
@@ -171,6 +184,8 @@ func (ae *AppEnvs) Load() {
 	ae.GmailAddr = gmailAddr
 	ae.LLMProvider = llmProvider
 	ae.OpenAiApiKey = openaiApiKey
+	ae.IsEnableMorPaddle = isEnableMorPaddle
+	ae.PaddleApiKey = paddleApiKey
 	ae.JWTAccessSecret = mustGetEnv("JWT_ACCESS_TOKEN")
 	ae.JWTRefreshSecret = mustGetEnv("JWT_REFRESH_TOKEN")
 	ae.JWTIssuer = mustGetEnv("JWT_ISS")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,6 +5,7 @@ type DBProvider string
 type FSProvider string
 type LLMProvider string
 
+// There may be several cases where you use one or the other provider where you use both where it is optional
 const (
 	MailGmail  MailerProvider = "gmail"
 	MailResend MailerProvider = "resend"

--- a/internal/paddle/client.go
+++ b/internal/paddle/client.go
@@ -1,0 +1,19 @@
+package paddle
+
+import (
+	paddle "github.com/PaddleHQ/paddle-go-sdk/v5"
+)
+
+type PaddleClient struct {
+	Client *paddle.SDK
+}
+
+func NewPaddleClient(apiKey string) (*PaddleClient, error) {
+	client, err := paddle.New(apiKey, paddle.WithBaseURL(paddle.SandboxBaseURL))
+	if err != nil {
+		return nil, err
+	}
+	return &PaddleClient{
+		Client: client,
+	}, nil
+}


### PR DESCRIPTION
- Add Paddle client with SDK v5 integration
- Add IsEnableMorPaddle and PaddleApiKey to AppEnvs
- Configure Paddle via env vars (IS_ENABLE_MOR_PADDLE, PADDLE_API_KEY)
- Add PaddleCli to AppClients with conditional initialization
- Add payments documentation comparing MoR vs Payment Processor
- Add Paddle env vars to .env.example

Features:
- Optional Paddle integration via environment variable
- Sandbox mode for development
- Merchant of Record (MoR) support
- Documentation for payment strategy decision

Close #94 